### PR TITLE
Fix client resource management and use persistent client for tool execution

### DIFF
--- a/packages/passthrough-mcp-server/src/server/passthrough.ts
+++ b/packages/passthrough-mcp-server/src/server/passthrough.ts
@@ -16,7 +16,7 @@ import {
   processRequestThroughHooks,
   processResponseThroughHooks,
 } from "../hooks/processor.js";
-import type { ClientFactory } from "../types/client.js";
+import type { ClientFactory, PassthroughClient } from "../types/client.js";
 import type { Config } from "../utils/config.js";
 import { logger } from "../utils/logger.js";
 import { getOrCreateSession } from "../utils/session.js";
@@ -34,7 +34,7 @@ import { getDiscoveredTools } from "./server.js";
 export function createPassthroughHandler(
   config: Config,
   toolName: string,
-  clientFactory?: ClientFactory,
+  targetClient: PassthroughClient,
 ) {
   return async function passthrough(
     args: unknown,
@@ -44,11 +44,7 @@ export function createPassthroughHandler(
     const sessionId = session?.id || "default";
 
     // Get or create session with target client
-    const sessionData = await getOrCreateSession(sessionId, () =>
-      clientFactory
-        ? clientFactory(config.target, sessionId, config.clientInfo)
-        : createTargetClient(config.target, sessionId, config.clientInfo),
-    );
+    const sessionData = await getOrCreateSession(sessionId, targetClient);
 
     // Increment request counter
     sessionData.requestCount += 1;

--- a/packages/passthrough-mcp-server/src/server/server.ts
+++ b/packages/passthrough-mcp-server/src/server/server.ts
@@ -69,7 +69,7 @@ export async function discoverAndRegisterTools(
   clientFactory?: ClientFactory,
 ): Promise<void> {
   // Create a temporary client to discover available tools
-  const tempClient = clientFactory
+  const targetClient = clientFactory
     ? await clientFactory(config.target, "discovery", config.clientInfo)
     : await createTargetClient(config.target, "discovery", config.clientInfo);
 
@@ -99,7 +99,7 @@ export async function discoverAndRegisterTools(
   }
 
   // Get list of tools from the target server
-  const { tools } = await tempClient.listTools();
+  const { tools } = await targetClient.listTools();
   logger.info(`Discovered ${tools.length} tools from target server`);
   logger.debug(`Raw: ${JSON.stringify(tools)}`);
 
@@ -146,7 +146,7 @@ export async function discoverAndRegisterTools(
     const toolHandler = createPassthroughHandler(
       config,
       tool.name,
-      clientFactory,
+      targetClient,
     );
 
     // Extract parameters from the tool definition

--- a/packages/passthrough-mcp-server/src/types/client.ts
+++ b/packages/passthrough-mcp-server/src/types/client.ts
@@ -26,6 +26,11 @@ export interface PassthroughClient {
     arguments?: { [x: string]: unknown };
     _meta?: { [x: string]: unknown; progressToken?: string | number };
   }): Promise<CallToolResult>;
+
+  /**
+   * Close the client connection and clean up resources
+   */
+  close(): Promise<void>;
 }
 
 /**

--- a/packages/passthrough-mcp-server/src/utils/session.test.ts
+++ b/packages/passthrough-mcp-server/src/utils/session.test.ts
@@ -30,41 +30,52 @@ describe("Session Management", () => {
 
   describe("getOrCreateSession", () => {
     it("should create new session if not exists", async () => {
-      const mockClient = { close: vi.fn() };
-      const createClient = vi.fn().mockResolvedValue(mockClient);
+      const mockClient = {
+        listTools: vi.fn(),
+        callTool: vi.fn(),
+        close: vi.fn(),
+      };
 
-      const session = await getOrCreateSession("test-session", createClient);
+      const session = await getOrCreateSession("test-session", mockClient);
 
       expect(session).toBeDefined();
       expect(session.id).toBe("test-session");
       expect(session.targetClient).toBe(mockClient);
       expect(session.requestCount).toBe(0);
-      expect(createClient).toHaveBeenCalledTimes(1);
     });
 
     it("should return existing session", async () => {
-      const mockClient = { close: vi.fn() };
-      const createClient = vi.fn().mockResolvedValue(mockClient);
+      const mockClient = {
+        listTools: vi.fn(),
+        callTool: vi.fn(),
+        close: vi.fn(),
+      };
 
-      const session1 = await getOrCreateSession("test-session", createClient);
+      const session1 = await getOrCreateSession("test-session", mockClient);
       session1.requestCount = 5;
 
-      const session2 = await getOrCreateSession("test-session", createClient);
+      const session2 = await getOrCreateSession("test-session", mockClient);
 
       expect(session2).toBe(session1);
       expect(session2.requestCount).toBe(5);
-      expect(createClient).toHaveBeenCalledTimes(1); // Only called once
     });
 
     it("should handle multiple sessions", async () => {
-      const mockClient1 = { close: vi.fn(), id: "client1" };
-      const mockClient2 = { close: vi.fn(), id: "client2" };
+      const mockClient1 = {
+        listTools: vi.fn(),
+        callTool: vi.fn(),
+        close: vi.fn(),
+        id: "client1",
+      };
+      const mockClient2 = {
+        listTools: vi.fn(),
+        callTool: vi.fn(),
+        close: vi.fn(),
+        id: "client2",
+      };
 
-      const createClient1 = vi.fn().mockResolvedValue(mockClient1);
-      const createClient2 = vi.fn().mockResolvedValue(mockClient2);
-
-      const session1 = await getOrCreateSession("session-1", createClient1);
-      const session2 = await getOrCreateSession("session-2", createClient2);
+      const session1 = await getOrCreateSession("session-1", mockClient1);
+      const session2 = await getOrCreateSession("session-2", mockClient2);
 
       expect(session1.id).toBe("session-1");
       expect(session2.id).toBe("session-2");
@@ -76,26 +87,36 @@ describe("Session Management", () => {
 
   describe("clearSession", () => {
     it("should clear specific session", async () => {
-      const mockClient = { close: vi.fn() };
-      const createClient = vi.fn().mockResolvedValue(mockClient);
+      const mockClient1 = {
+        listTools: vi.fn(),
+        callTool: vi.fn(),
+        close: vi.fn(),
+      };
+      const mockClient2 = {
+        listTools: vi.fn(),
+        callTool: vi.fn(),
+        close: vi.fn(),
+      };
 
-      const session1 = await getOrCreateSession("test-session", createClient);
+      const session1 = await getOrCreateSession("test-session", mockClient1);
       session1.requestCount = 10;
 
       clearSession("test-session");
 
-      const session2 = await getOrCreateSession("test-session", createClient);
+      const session2 = await getOrCreateSession("test-session", mockClient2);
       expect(session2).not.toBe(session1);
       expect(session2.requestCount).toBe(0);
-      expect(createClient).toHaveBeenCalledTimes(2);
     });
 
     it("should not affect other sessions", async () => {
-      const mockClient = { close: vi.fn() };
-      const createClient = vi.fn().mockResolvedValue(mockClient);
+      const mockClient = {
+        listTools: vi.fn(),
+        callTool: vi.fn(),
+        close: vi.fn(),
+      };
 
-      await getOrCreateSession("session-1", createClient);
-      await getOrCreateSession("session-2", createClient);
+      await getOrCreateSession("session-1", mockClient);
+      await getOrCreateSession("session-2", mockClient);
 
       clearSession("session-1");
 
@@ -105,12 +126,15 @@ describe("Session Management", () => {
 
   describe("clearAllSessions", () => {
     it("should clear all sessions", async () => {
-      const mockClient = { close: vi.fn() };
-      const createClient = vi.fn().mockResolvedValue(mockClient);
+      const mockClient = {
+        listTools: vi.fn(),
+        callTool: vi.fn(),
+        close: vi.fn(),
+      };
 
-      await getOrCreateSession("session-1", createClient);
-      await getOrCreateSession("session-2", createClient);
-      await getOrCreateSession("session-3", createClient);
+      await getOrCreateSession("session-1", mockClient);
+      await getOrCreateSession("session-2", mockClient);
+      await getOrCreateSession("session-3", mockClient);
 
       expect(getSessionCount()).toBe(3);
 

--- a/packages/passthrough-mcp-server/src/utils/session.ts
+++ b/packages/passthrough-mcp-server/src/utils/session.ts
@@ -22,10 +22,9 @@ const sessions = new Map<string, SessionData>();
  */
 export async function getOrCreateSession(
   sessionId: string,
-  createClient: () => Promise<PassthroughClient>,
+  targetClient: PassthroughClient,
 ): Promise<SessionData> {
   if (!sessions.has(sessionId)) {
-    const targetClient = await createClient();
     sessions.set(sessionId, {
       id: sessionId,
       targetClient,


### PR DESCRIPTION
## Summary
- Just create a single PassthroughClient instance, so that not two are kept alive during the creation of one passthrough-mcp-server
- Refactored session management to use persistent client architecture instead of creating new clients per request
- Updated `PassthroughClient` interface to include `close()` method for proper resource cleanup

## Changes
- Added `close()` method to `PassthroughClient` interface
- Modified `discoverAndRegisterTools()` to create one persistent client for tool execution after discovery
- Updated `createPassthroughHandler()` to accept persistent client directly instead of factory function
- Simplified session management to work with persistent client approach
- Fixed all tests to match new session interface
- Ensured linting compliance

## Test plan
- [x] All existing tests pass
- [x] Session management tests updated and passing
- [x] Integration tests verify persistent client behavior
- [x] Linting passes without issues