### PR TITLE
Improve client connection lifecycle management

### DIFF
--- a/packages/passthrough-mcp-server/src/createPassthroughProxy.test.ts
+++ b/packages/passthrough-mcp-server/src/createPassthroughProxy.test.ts
@@ -155,6 +155,7 @@ describe("createPassthroughProxy", () => {
       async (): Promise<PassthroughClient> => ({
         listTools: vi.fn(),
         callTool: vi.fn(),
+        close: vi.fn(),
       }),
     );
 
@@ -166,7 +167,6 @@ describe("createPassthroughProxy", () => {
     expect(discoverAndRegisterTools).toHaveBeenCalledWith(
       expect.any(Object),
       mockConfig,
-      mockClientFactory,
     );
   });
 
@@ -209,7 +209,7 @@ describe("createPassthroughProxy", () => {
       transportType: "stdio",
       target: {
         url: "http://localhost:33000",
-        type: "stream",
+        transportType: "httpStream",
       },
     };
 
@@ -233,7 +233,7 @@ describe("createPassthroughProxy", () => {
 
     await expect(
       createPassthroughProxy({
-        config: mockConfig,
+        ...mockConfig,
       }),
     ).rejects.toThrow("Start failed");
   });

--- a/packages/passthrough-mcp-server/src/createPassthroughProxy.ts
+++ b/packages/passthrough-mcp-server/src/createPassthroughProxy.ts
@@ -11,6 +11,7 @@ import { getServerTransportConfig } from "./server/transport.js";
 import type { ClientFactory } from "./types/client.js";
 import type { Config } from "./utils/config.js";
 import { logger } from "./utils/logger.js";
+import { clearAllSessions } from "./utils/session.js";
 
 export type PassthroughProxyOptions = Config & {
   /**
@@ -139,6 +140,9 @@ export async function createPassthroughProxy(
       logger.warn("Server is not started");
       return;
     }
+
+    // stop all clients.
+    await clearAllSessions();
 
     await server.stop();
     isStarted = false;

--- a/packages/passthrough-mcp-server/src/createPassthroughProxy.ts
+++ b/packages/passthrough-mcp-server/src/createPassthroughProxy.ts
@@ -11,7 +11,7 @@ import { getServerTransportConfig } from "./server/transport.js";
 import type { ClientFactory } from "./types/client.js";
 import type { Config } from "./utils/config.js";
 import { logger } from "./utils/logger.js";
-import { clearAllSessions } from "./utils/session.js";
+import { clearAllSessions, setSessionClientFactory } from "./utils/session.js";
 
 export type PassthroughProxyOptions = Config & {
   /**
@@ -99,11 +99,14 @@ export async function createPassthroughProxy(
 ): Promise<PassthroughProxy> {
   const { clientFactory, autoStart = true, ...config } = options;
 
+  // Configure the session client factory
+  setSessionClientFactory(clientFactory);
+
   // Create the server
   const server = createServer(config.serverInfo);
 
   // Discover and register tools from the target server
-  await discoverAndRegisterTools(server, config, clientFactory);
+  await discoverAndRegisterTools(server, config);
 
   // Get transport configuration based on transport type
   const transportConfig =

--- a/packages/passthrough-mcp-server/src/server/passthrough.ts
+++ b/packages/passthrough-mcp-server/src/server/passthrough.ts
@@ -10,19 +10,16 @@
 
 import type { ToolCall } from "@civic/hook-common";
 import type { Context } from "fastmcp";
-import { createTargetClient } from "../client/client.js";
 import { getHookClients } from "../hooks/manager.js";
 import {
   processRequestThroughHooks,
   processResponseThroughHooks,
 } from "../hooks/processor.js";
-import type { ClientFactory } from "../types/client.js";
 import type { Config } from "../utils/config.js";
 import { logger } from "../utils/logger.js";
 import {
   DEFAULT_SESSION_ID,
-  type SessionData,
-  getOrCreateSession,
+  getOrCreateSessionForRequest,
 } from "../utils/session.js";
 import { type AuthSessionData, getDiscoveredTools } from "./server.js";
 
@@ -35,11 +32,7 @@ import { type AuthSessionData, getDiscoveredTools } from "./server.js";
  * If hooks are configured, tool calls will be sent to the hooks for processing
  * before being forwarded to the target server.
  */
-export function createPassthroughHandler(
-  config: Config,
-  toolName: string,
-  getSessionForRequest: (sessionId: string) => Promise<SessionData>,
-) {
+export function createPassthroughHandler(config: Config, toolName: string) {
   return async function passthrough(
     args: unknown,
     context: Context<AuthSessionData>,
@@ -48,7 +41,7 @@ export function createPassthroughHandler(
     const sessionId = session?.id || DEFAULT_SESSION_ID;
 
     // Get or create session with target client
-    const sessionData = await getSessionForRequest(sessionId);
+    const sessionData = await getOrCreateSessionForRequest(sessionId, config);
 
     // Find the tool definition from cached tools
     const discoveredTools = getDiscoveredTools();

--- a/packages/passthrough-mcp-server/src/types/client.ts
+++ b/packages/passthrough-mcp-server/src/types/client.ts
@@ -26,6 +26,11 @@ export interface PassthroughClient {
     arguments?: { [x: string]: unknown };
     _meta?: { [x: string]: unknown; progressToken?: string | number };
   }): Promise<CallToolResult>;
+
+  /**
+   * Closes the connection.
+   */
+  close(): Promise<void>;
 }
 
 /**

--- a/packages/passthrough-mcp-server/src/utils/session.test.ts
+++ b/packages/passthrough-mcp-server/src/utils/session.test.ts
@@ -8,8 +8,8 @@ import {
 } from "./session.js";
 
 describe("Session Management", () => {
-  beforeEach(() => {
-    clearAllSessions();
+  beforeEach(async () => {
+    await clearAllSessions();
   });
 
   describe("generateSessionId", () => {
@@ -82,7 +82,7 @@ describe("Session Management", () => {
       const session1 = await getOrCreateSession("test-session", createClient);
       session1.requestCount = 10;
 
-      clearSession("test-session");
+      await clearSession("test-session");
 
       const session2 = await getOrCreateSession("test-session", createClient);
       expect(session2).not.toBe(session1);
@@ -97,7 +97,7 @@ describe("Session Management", () => {
       await getOrCreateSession("session-1", createClient);
       await getOrCreateSession("session-2", createClient);
 
-      clearSession("session-1");
+      await clearSession("session-1");
 
       expect(getSessionCount()).toBe(1);
     });
@@ -114,7 +114,7 @@ describe("Session Management", () => {
 
       expect(getSessionCount()).toBe(3);
 
-      clearAllSessions();
+      await clearAllSessions();
 
       expect(getSessionCount()).toBe(0);
     });

--- a/packages/passthrough-mcp-server/src/utils/session.test.ts
+++ b/packages/passthrough-mcp-server/src/utils/session.test.ts
@@ -1,11 +1,22 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
+import type { ClientFactory } from "../types/client.js";
+import type { Config } from "./config.js";
 import {
   clearAllSessions,
   clearSession,
   generateSessionId,
   getOrCreateSession,
   getSessionCount,
+  setSessionClientFactory,
 } from "./session.js";
+
+function createMockConfig(): Config {
+  return {
+    transportType: "stdio",
+    target: { transportType: "httpStream", url: "http://localhost:3000" },
+    clientInfo: { name: "test", version: "1.0.0" },
+  };
+}
 
 describe("Session Management", () => {
   beforeEach(async () => {
@@ -31,40 +42,60 @@ describe("Session Management", () => {
   describe("getOrCreateSession", () => {
     it("should create new session if not exists", async () => {
       const mockClient = { close: vi.fn() };
-      const createClient = vi.fn().mockResolvedValue(mockClient);
+      const mockClientFactory: ClientFactory = vi
+        .fn()
+        .mockResolvedValue(mockClient);
+      const mockConfig = createMockConfig();
 
-      const session = await getOrCreateSession("test-session", createClient);
+      setSessionClientFactory(mockClientFactory);
+
+      const session = await getOrCreateSession("test-session", mockConfig);
 
       expect(session).toBeDefined();
       expect(session.id).toBe("test-session");
       expect(session.targetClient).toBe(mockClient);
       expect(session.requestCount).toBe(0);
-      expect(createClient).toHaveBeenCalledTimes(1);
+      expect(mockClientFactory).toHaveBeenCalledTimes(1);
+      expect(mockClientFactory).toHaveBeenCalledWith(
+        mockConfig.target,
+        "test-session",
+        mockConfig.clientInfo,
+      );
     });
 
     it("should return existing session", async () => {
       const mockClient = { close: vi.fn() };
-      const createClient = vi.fn().mockResolvedValue(mockClient);
+      const mockClientFactory: ClientFactory = vi
+        .fn()
+        .mockResolvedValue(mockClient);
+      const mockConfig = createMockConfig();
 
-      const session1 = await getOrCreateSession("test-session", createClient);
+      setSessionClientFactory(mockClientFactory);
+
+      const session1 = await getOrCreateSession("test-session", mockConfig);
       session1.requestCount = 5;
 
-      const session2 = await getOrCreateSession("test-session", createClient);
+      const session2 = await getOrCreateSession("test-session", mockConfig);
 
       expect(session2).toBe(session1);
       expect(session2.requestCount).toBe(5);
-      expect(createClient).toHaveBeenCalledTimes(1); // Only called once
+      expect(mockClientFactory).toHaveBeenCalledTimes(1); // Only called once
     });
 
     it("should handle multiple sessions", async () => {
       const mockClient1 = { close: vi.fn(), id: "client1" };
       const mockClient2 = { close: vi.fn(), id: "client2" };
 
-      const createClient1 = vi.fn().mockResolvedValue(mockClient1);
-      const createClient2 = vi.fn().mockResolvedValue(mockClient2);
+      const mockClientFactory = vi
+        .fn()
+        .mockResolvedValueOnce(mockClient1)
+        .mockResolvedValueOnce(mockClient2);
+      const mockConfig = createMockConfig();
 
-      const session1 = await getOrCreateSession("session-1", createClient1);
-      const session2 = await getOrCreateSession("session-2", createClient2);
+      setSessionClientFactory(mockClientFactory);
+
+      const session1 = await getOrCreateSession("session-1", mockConfig);
+      const session2 = await getOrCreateSession("session-2", mockConfig);
 
       expect(session1.id).toBe("session-1");
       expect(session2.id).toBe("session-2");
@@ -76,47 +107,76 @@ describe("Session Management", () => {
 
   describe("clearSession", () => {
     it("should clear specific session", async () => {
-      const mockClient = { close: vi.fn() };
-      const createClient = vi.fn().mockResolvedValue(mockClient);
+      const mockClient1 = { close: vi.fn() };
+      const mockClient2 = { close: vi.fn() };
+      const mockClientFactory = vi
+        .fn()
+        .mockResolvedValueOnce(mockClient1)
+        .mockResolvedValueOnce(mockClient2);
+      const mockConfig = createMockConfig();
 
-      const session1 = await getOrCreateSession("test-session", createClient);
+      setSessionClientFactory(mockClientFactory);
+
+      const session1 = await getOrCreateSession("test-session", mockConfig);
       session1.requestCount = 10;
 
       await clearSession("test-session");
 
-      const session2 = await getOrCreateSession("test-session", createClient);
+      const session2 = await getOrCreateSession("test-session", mockConfig);
       expect(session2).not.toBe(session1);
       expect(session2.requestCount).toBe(0);
-      expect(createClient).toHaveBeenCalledTimes(2);
+      expect(mockClientFactory).toHaveBeenCalledTimes(2);
+      expect(mockClient1.close).toHaveBeenCalledTimes(1);
     });
 
     it("should not affect other sessions", async () => {
-      const mockClient = { close: vi.fn() };
-      const createClient = vi.fn().mockResolvedValue(mockClient);
+      const mockClient1 = { close: vi.fn() };
+      const mockClient2 = { close: vi.fn() };
+      const mockClientFactory = vi
+        .fn()
+        .mockResolvedValueOnce(mockClient1)
+        .mockResolvedValueOnce(mockClient2);
+      const mockConfig = createMockConfig();
 
-      await getOrCreateSession("session-1", createClient);
-      await getOrCreateSession("session-2", createClient);
+      setSessionClientFactory(mockClientFactory);
+
+      await getOrCreateSession("session-1", mockConfig);
+      await getOrCreateSession("session-2", mockConfig);
 
       await clearSession("session-1");
 
       expect(getSessionCount()).toBe(1);
+      expect(mockClient1.close).toHaveBeenCalledTimes(1);
+      expect(mockClient2.close).not.toHaveBeenCalled();
     });
   });
 
   describe("clearAllSessions", () => {
     it("should clear all sessions", async () => {
-      const mockClient = { close: vi.fn() };
-      const createClient = vi.fn().mockResolvedValue(mockClient);
+      const mockClient1 = { close: vi.fn() };
+      const mockClient2 = { close: vi.fn() };
+      const mockClient3 = { close: vi.fn() };
+      const mockClientFactory = vi
+        .fn()
+        .mockResolvedValueOnce(mockClient1)
+        .mockResolvedValueOnce(mockClient2)
+        .mockResolvedValueOnce(mockClient3);
+      const mockConfig = createMockConfig();
 
-      await getOrCreateSession("session-1", createClient);
-      await getOrCreateSession("session-2", createClient);
-      await getOrCreateSession("session-3", createClient);
+      setSessionClientFactory(mockClientFactory);
+
+      await getOrCreateSession("session-1", mockConfig);
+      await getOrCreateSession("session-2", mockConfig);
+      await getOrCreateSession("session-3", mockConfig);
 
       expect(getSessionCount()).toBe(3);
 
       await clearAllSessions();
 
       expect(getSessionCount()).toBe(0);
+      expect(mockClient1.close).toHaveBeenCalledTimes(1);
+      expect(mockClient2.close).toHaveBeenCalledTimes(1);
+      expect(mockClient3.close).toHaveBeenCalledTimes(1);
     });
   });
 });

--- a/packages/passthrough-mcp-server/src/utils/session.ts
+++ b/packages/passthrough-mcp-server/src/utils/session.ts
@@ -6,7 +6,9 @@
  * Each session maintains its own connection to the target MCP server.
  */
 
-import type { PassthroughClient } from "../types/client.js";
+import { createTargetClient } from "../client/client.js";
+import type { ClientFactory, PassthroughClient } from "../types/client.js";
+import type { Config } from "./config.js";
 
 export interface SessionData {
   id: string;
@@ -20,15 +22,45 @@ const sessions = new Map<string, SessionData>();
 // one (stdio or start-up client)
 export const DEFAULT_SESSION_ID = "default";
 
+// Global client factory
+let clientFactory: ClientFactory | undefined = undefined;
+
+/**
+ * Set the client factory and config for session management
+ */
+export function setSessionClientFactory(
+  factory: ClientFactory | undefined,
+): void {
+  clientFactory = factory;
+}
+
+/**
+ * Create a client using the configured factory or default implementation
+ */
+async function createClientForSession(
+  sessionId: string,
+  config: Config,
+): Promise<PassthroughClient> {
+  if (!config) {
+    throw new Error(
+      "Session config not set. Call setSessionClientFactory first.",
+    );
+  }
+
+  return clientFactory
+    ? clientFactory(config.target, sessionId, config.clientInfo)
+    : createTargetClient(config.target, sessionId, config.clientInfo);
+}
+
 /**
  * Get or create session data for a given session ID
  */
 export async function getOrCreateSession(
   sessionId: string,
-  createClient: () => Promise<PassthroughClient>,
+  config: Config,
 ): Promise<SessionData> {
   if (!sessions.has(sessionId)) {
-    const targetClient = await createClient();
+    const targetClient = await createClientForSession(sessionId, config);
     sessions.set(sessionId, {
       id: sessionId,
       targetClient,
@@ -41,6 +73,22 @@ export async function getOrCreateSession(
     throw new Error("Session should exist after creation");
   }
   return session;
+}
+
+/**
+ * Get or create session, increase request count and return targetClient
+ */
+export async function getOrCreateSessionForRequest(
+  sessionId: string,
+  config: Config,
+): Promise<SessionData> {
+  // Get or create session with target client
+  const sessionData = await getOrCreateSession(sessionId, config);
+
+  // Increment request counter
+  sessionData.requestCount += 1;
+
+  return sessionData;
 }
 
 /**

--- a/packages/passthrough-mcp-server/src/utils/session.ts
+++ b/packages/passthrough-mcp-server/src/utils/session.ts
@@ -16,6 +16,9 @@ export interface SessionData {
 
 // Global session store
 const sessions = new Map<string, SessionData>();
+// Default Session ID for client operations that are not associated with
+// one (stdio or start-up client)
+export const DEFAULT_SESSION_ID = "default";
 
 /**
  * Get or create session data for a given session ID
@@ -43,14 +46,23 @@ export async function getOrCreateSession(
 /**
  * Clear a specific session
  */
-export function clearSession(sessionId: string): void {
+export async function clearSession(sessionId: string): Promise<void> {
+  const session = sessions.get(sessionId);
+  if (session) {
+    await session.targetClient.close();
+  }
   sessions.delete(sessionId);
 }
 
 /**
  * Clear all sessions
  */
-export function clearAllSessions(): void {
+export async function clearAllSessions(): Promise<void> {
+  await Promise.all(
+    Array.from(sessions.values()).map((session) =>
+      session.targetClient.close(),
+    ),
+  );
   sessions.clear();
 }
 


### PR DESCRIPTION
## Summary
- Client for listing tools is also managed in a session.
- For stdio, that means that the "default" session is being reused and only one client is generated
- For http/sse one default client will be generated for listing tools, all other clients are mapped to sessionIds. 
- Refactored session management to use configurable client factory pattern for better reusability             
- Enhanced session management to properly close client connections during cleanup
- Updated PassthroughClient interface to include close() method for connection lifecycle management

## Test plan
- [x] All existing tests pass (85/85)
- [x] Lint checks pass with no issues
- [x] Type checking passes
- [x] Updated session tests to handle async cleanup operations