### PR TITLE
chore: bump @civic/passthrough-mcp-server to v0.3.0

### DIFF
--- a/packages/passthrough-mcp-server/CHANGELOG.md
+++ b/packages/passthrough-mcp-server/CHANGELOG.md
@@ -5,7 +5,7 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [Unreleased]
+## [0.3.0] - 2025-07-03
 
 ### Added
 - MCP Authorization specification compliance

--- a/packages/passthrough-mcp-server/package.json
+++ b/packages/passthrough-mcp-server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@civic/passthrough-mcp-server",
-  "version": "0.2.2",
+  "version": "0.3.0",
   "description": "A Model Context Protocol (MCP) server that acts as a passthrough proxy with hook middleware support",
   "keywords": [
     "mcp",


### PR DESCRIPTION
Major release with MCP Authorization specification compliance and architectural improvements.
