### PR TITLE
fix: use pnpm publish to resolve workspace dependencies

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -49,7 +49,7 @@ jobs:
           else
             echo "Publishing @civic/$PACKAGE_SUFFIX"
             cd "packages/$PACKAGE_SUFFIX"
-            npm publish --access public --provenance
+            pnpm publish --access public --no-git-checks
           fi
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_PUBLISH_TOKEN }}

--- a/packages/passthrough-mcp-server/CHANGELOG.md
+++ b/packages/passthrough-mcp-server/CHANGELOG.md
@@ -5,6 +5,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.4.1] - 2025-07-04
+
+### Fixed
+- Fixed workspace dependency resolution in published package by using pnpm publish instead of npm publish
+
 ## [0.4.0] - 2025-07-04
 
 ### Added

--- a/packages/passthrough-mcp-server/package.json
+++ b/packages/passthrough-mcp-server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@civic/passthrough-mcp-server",
-  "version": "0.4.0",
+  "version": "0.4.1",
   "description": "A Model Context Protocol (MCP) server that acts as a passthrough proxy with hook middleware support",
   "keywords": [
     "mcp",


### PR DESCRIPTION
- Update CI workflow to use pnpm publish instead of npm publish for individual packages
- This ensures workspace: protocol dependencies are converted to real versions
- Bump passthrough-mcp-server to 0.4.1

