### PR TITLE
chore: prepare release for hook-common v0.1.0, passthrough-mcp-server…

### DIFF
--- a/packages/hook-common/CHANGELOG.md
+++ b/packages/hook-common/CHANGELOG.md
@@ -7,6 +7,28 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.1.0] - 2025-01-12
+
+### Changed
+- **BREAKING**: Complete refactor to use MCP SDK types directly
+- **BREAKING**: Changed from custom wrapper types to CallToolRequest/CallToolResult
+- **BREAKING**: Replaced HookResponse with discriminated unions (resultType: "continue" | "abort" | "respond")
+- **BREAKING**: Renamed response type from "reject" to "abort"
+- **BREAKING**: Hook interface now requires a `name` getter
+- **BREAKING**: Removed HookClient in favor of Hook interface
+- Simplified hook interface by removing unnecessary abstractions
+- Improved type safety with proper MCP SDK integration
+
+### Added
+- Support for optional hook methods (processToolsList, processToolsListResponse)
+- Better error handling with abort responses
+- Export of MCP SDK types for convenience
+
+### Removed
+- HookClient class (replaced with Hook interface)
+- Custom ToolCall type (using CallToolRequest instead)
+- HookResponse type (using discriminated unions instead)
+
 ## [0.0.4] - 2025-06-26
 
 ### Added

--- a/packages/hook-common/package.json
+++ b/packages/hook-common/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@civic/hook-common",
-  "version": "0.0.4",
+  "version": "0.1.0",
   "description": "Common utilities and types for implementing MCP server hooks",
   "keywords": ["mcp", "hooks", "middleware", "toolcall", "interceptor"],
   "homepage": "https://github.com/civicteam/mcp-hooks/tree/main/packages/hook-common",

--- a/packages/local-tools-hook/CHANGELOG.md
+++ b/packages/local-tools-hook/CHANGELOG.md
@@ -1,0 +1,19 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [0.1.0] - 2025-01-12
+
+### Added
+- Initial public release of @civic/local-tools-hook
+- Support for defining local tools with Zod schemas
+- Integration with passthrough MCP server
+- Automatic tool list merging with remote servers
+- Full TypeScript support with proper type inference
+- Comprehensive test coverage
+
+### Changed
+- Renamed `paramsSchemaOrAnnotations` to `paramsSchema` for clarity

--- a/packages/local-tools-hook/package.json
+++ b/packages/local-tools-hook/package.json
@@ -1,9 +1,26 @@
 {
   "name": "@civic/local-tools-hook",
-  "version": "0.0.1",
-  "private": true,
+  "version": "0.1.0",
+  "description": "A programmatic hook for adding local tools to passthrough MCP servers",
+  "keywords": ["mcp", "hooks", "local-tools", "passthrough", "middleware"],
+  "homepage": "https://github.com/civicteam/mcp-hooks/tree/main/packages/local-tools-hook",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/civicteam/mcp-hooks.git",
+    "directory": "packages/local-tools-hook"
+  },
+  "license": "MIT",
+  "author": "Civic Technologies, Inc.",
   "main": "./dist/index.js",
+  "types": "./dist/index.d.ts",
   "type": "module",
+  "exports": {
+    ".": {
+      "types": "./dist/index.d.ts",
+      "import": "./dist/index.js"
+    }
+  },
+  "files": ["dist", "README.md", "CHANGELOG.md", "package.json"],
   "scripts": {
     "dev": "tsx watch src/index.ts",
     "build": "tsc",
@@ -12,7 +29,8 @@
     "test:coverage": "vitest run --coverage",
     "lint": "biome check .",
     "lint:fix": "biome check --fix .",
-    "start": "node dist/index.js"
+    "start": "node dist/index.js",
+    "prepublishOnly": "pnpm run lint && pnpm run typecheck && CI=1 pnpm run test && pnpm run build"
   },
   "dependencies": {
     "@civic/hook-common": "workspace:^",
@@ -26,5 +44,9 @@
     "tsx": "^4.19.4",
     "typescript": "^5.2.2",
     "vitest": "^2.1.8"
+  },
+  "publishConfig": {
+    "access": "public",
+    "registry": "https://registry.npmjs.org/"
   }
 }

--- a/packages/passthrough-mcp-server/CHANGELOG.md
+++ b/packages/passthrough-mcp-server/CHANGELOG.md
@@ -5,6 +5,28 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.5.0] - 2025-01-12
+
+### Changed
+- **BREAKING**: Updated to use @civic/hook-common v0.1.0 with new hook interface
+- **BREAKING**: Hooks now use MCP SDK types directly (CallToolRequest, CallToolResult)
+- **BREAKING**: Hook responses use discriminated unions with resultType field
+- **BREAKING**: Removed apply.ts module - processor functions are now exported directly
+- Simplified hook processing by removing unnecessary abstractions
+- Better TypeScript support with improved type exports
+
+### Added
+- Direct export of processor functions (processRequestThroughHooks, etc.)
+- Support for local programmatic hooks alongside remote HTTP hooks
+- Export of hook creation utilities for better integration
+
+### Fixed
+- Type inference issues with transport-specific proxy creation
+
+### Removed
+- apply.ts module and applyHooks function (use processor functions directly)
+- Unnecessary type wrappers around MCP SDK types
+
 ## [0.4.1] - 2025-07-04
 
 ### Fixed

--- a/packages/passthrough-mcp-server/package.json
+++ b/packages/passthrough-mcp-server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@civic/passthrough-mcp-server",
-  "version": "0.4.1",
+  "version": "0.5.0",
   "description": "A Model Context Protocol (MCP) server that acts as a passthrough proxy with hook middleware support",
   "keywords": [
     "mcp",


### PR DESCRIPTION
… v0.5.0, and local-tools-hook v0.1.0

- hook-common v0.1.0: Major refactor to use MCP SDK types directly
- passthrough-mcp-server v0.5.0: Updated to use new hook interface
- local-tools-hook v0.1.0: Initial public release

BREAKING CHANGES:
- hook-common: Complete interface change to use MCP SDK types
- passthrough-mcp-server: Removed apply.ts, hooks use new interface
