### PR TITLE
chore: bump versions for release

### DIFF
--- a/packages/hook-common/package.json
+++ b/packages/hook-common/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@civic/hook-common",
-  "version": "0.2.1",
+  "version": "0.2.2",
   "description": "Common utilities and types for implementing MCP server hooks",
   "keywords": ["mcp", "hooks", "middleware", "toolcall", "interceptor"],
   "homepage": "https://github.com/civicteam/mcp-hooks/tree/main/packages/hook-common",

--- a/packages/passthrough-mcp-server/package.json
+++ b/packages/passthrough-mcp-server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@civic/passthrough-mcp-server",
-  "version": "0.6.1",
+  "version": "0.6.2",
   "description": "A Model Context Protocol (MCP) server that acts as a passthrough proxy with hook middleware support",
   "keywords": [
     "mcp",


### PR DESCRIPTION
Bumping versions for release:
- @civic/hook-common: 0.2.1 → 0.2.2
- @civic/passthrough-mcp-server: 0.6.1 → 0.6.2

This release includes the fix for transport error hooks to support the 'respond' result type.