### PR TITLE
fix: add missing initialize transport error methods to LocalHookClient

### DIFF
--- a/packages/hook-common/package.json
+++ b/packages/hook-common/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@civic/hook-common",
-  "version": "0.2.2",
+  "version": "0.2.3",
   "description": "Common utilities and types for implementing MCP server hooks",
   "keywords": ["mcp", "hooks", "middleware", "toolcall", "interceptor"],
   "homepage": "https://github.com/civicteam/mcp-hooks/tree/main/packages/hook-common",

--- a/packages/hook-common/src/localClient.ts
+++ b/packages/hook-common/src/localClient.ts
@@ -7,11 +7,16 @@
 import type {
   CallToolRequest,
   CallToolResult,
+  InitializeRequest,
+  InitializeResult,
   ListToolsRequest,
   ListToolsResult,
 } from "@modelcontextprotocol/sdk/types.js";
 import type {
   Hook,
+  InitializeRequestHookResult,
+  InitializeResponseHookResult,
+  InitializeTransportErrorHookResult,
   ListToolsRequestHookResult,
   ListToolsResponseHookResult,
   ListToolsTransportErrorHookResult,
@@ -196,6 +201,98 @@ export class LocalHookClient implements Hook {
     } catch (hookError) {
       console.error(
         `Hook ${this.name} tools/list transport error processing failed:`,
+        hookError,
+      );
+      // On error, continue with unmodified error
+      return {
+        resultType: "continue",
+        error,
+      };
+    }
+  }
+
+  /**
+   * Process an initialize request through the hook
+   */
+  async processInitializeRequest(
+    request: InitializeRequest,
+  ): Promise<InitializeRequestHookResult> {
+    try {
+      // Check if hook supports initialize request processing
+      if (!this.hook.processInitializeRequest) {
+        return {
+          resultType: "continue",
+          request,
+        };
+      }
+      return await this.hook.processInitializeRequest(request);
+    } catch (error) {
+      console.error(
+        `Hook ${this.name} initialize request processing failed:`,
+        error,
+      );
+      // On error, continue with unmodified request
+      return {
+        resultType: "continue",
+        request,
+      };
+    }
+  }
+
+  /**
+   * Process an initialize response through the hook
+   */
+  async processInitializeResponse(
+    response: InitializeResult,
+    originalRequest: InitializeRequest,
+  ): Promise<InitializeResponseHookResult> {
+    try {
+      // Check if hook supports initialize response processing
+      if (!this.hook.processInitializeResponse) {
+        return {
+          resultType: "continue",
+          response,
+        };
+      }
+      return await this.hook.processInitializeResponse(
+        response,
+        originalRequest,
+      );
+    } catch (error) {
+      console.error(
+        `Hook ${this.name} initialize response processing failed:`,
+        error,
+      );
+      // On error, continue with unmodified response
+      return {
+        resultType: "continue",
+        response,
+      };
+    }
+  }
+
+  /**
+   * Process an initialize transport error through the hook
+   */
+  async processInitializeTransportError(
+    error: TransportError,
+    originalRequest: InitializeRequest,
+  ): Promise<InitializeTransportErrorHookResult> {
+    try {
+      // Check if hook supports initialize transport error processing
+      if (!this.hook.processInitializeTransportError) {
+        return {
+          resultType: "continue",
+          error,
+        };
+      }
+      return await this.hook.processInitializeTransportError(
+        error,
+        originalRequest,
+      );
+    } catch (hookError) {
+      console.error(
+        `Hook ${this.name} initialize transport error processing failed:`,
         hookError,
       );
       // On error, continue with unmodified error


### PR DESCRIPTION
## Summary
- Added missing `processInitializeTransportError` method to LocalHookClient
- Also added `processInitializeRequest` and `processInitializeResponse` methods for completeness
- Bumped @civic/hook-common version from 0.2.2 to 0.2.3

## Problem
The LocalHookClient was missing the implementation for `processInitializeTransportError`, preventing hooks like CivicAuthenticationHook from intercepting 401 errors during the initialize phase.

## Solution
Implemented all three missing initialize-related methods following the same pattern as existing methods:
- Check if the wrapped hook implements the method
- Return "continue" result if not implemented  
- Catch and log any errors, returning "continue" to avoid blocking

## Test Plan
- [x] Build passes (`pnpm build`)
- [x] Lint passes (`pnpm lint`)
- [x] All tests pass (`CI=1 pnpm test`)
- [x] Verified the compiled JavaScript contains the new methods