### PR TITLE
fix: wrap transport error hook responses in proper JSON-RPC format

### DIFF
--- a/packages/passthrough-mcp-server/package.json
+++ b/packages/passthrough-mcp-server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@civic/passthrough-mcp-server",
-  "version": "0.6.2",
+  "version": "0.6.3",
   "description": "A Model Context Protocol (MCP) server that acts as a passthrough proxy with hook middleware support",
   "keywords": [
     "mcp",

--- a/packages/passthrough-mcp-server/src/lib/hooks/transport-error.ts
+++ b/packages/passthrough-mcp-server/src/lib/hooks/transport-error.ts
@@ -48,8 +48,13 @@ export async function handleTransportError(
 
   if (errorResult.resultType === "respond") {
     // Hook has handled the error and provided a response
+    // Wrap the response in proper JSON-RPC format
     return {
-      message: errorResult.response,
+      message: {
+        jsonrpc: "2.0",
+        id: requestId,
+        result: errorResult.response,
+      } as JSONRPCResponse,
       headers: headers,
       statusCode: 200,
     };


### PR DESCRIPTION
## Summary
- Fixed handleTransportError to properly wrap hook responses in JSON-RPC format
- Updated tests to match the corrected behavior
- Bumped @civic/passthrough-mcp-server version from 0.6.2 to 0.6.3

## Problem
When a hook returns `resultType: "respond"` from a transport error handler (like when CivicAuthenticationHook handles a 401 error), the response was being returned as-is instead of being wrapped in proper JSON-RPC format. This caused the ProxyStdioServerTransport to treat it as an error because it didn't have the required `jsonrpc` property.

## Solution
Modified the handleTransportError function to wrap the response in proper JSON-RPC format:
```typescript
return {
  message: {
    jsonrpc: "2.0",
    id: requestId,
    result: errorResult.response,
  } as JSONRPCResponse,
  headers: headers,
  statusCode: 200,
};
```

## Test Plan
- [x] Updated unit tests to expect the wrapped format
- [x] All tests pass (`CI=1 pnpm test`)
- [x] Build passes (`pnpm build`)
- [x] Lint passes (`pnpm lint`)

This fix ensures that when the CivicAuthenticationHook successfully handles a 401 error and retries with authentication, the response is properly formatted for the MCP protocol.