### PR TITLE
feat: passthrough-mcp-server improvements and refactoring

### DIFF
--- a/packages/passthrough-mcp-server/README.md
+++ b/packages/passthrough-mcp-server/README.md
@@ -196,6 +196,50 @@ await context.connect(serverTransport, clientTransport);
 await context.close();
 ```
 
+### Target Configuration
+
+The `TargetConfig` interface uses discriminated unions for type safety, ensuring only valid properties are available for each transport type:
+
+#### HTTP Stream or SSE Transport
+```typescript
+{
+  transportType: "httpStream" | "sse";
+  url: string;                    // Target server URL
+  mcpPath?: string;              // MCP endpoint path (defaults to "/mcp")
+}
+```
+
+#### Custom Transport Factory
+```typescript
+{
+  transportType: "custom";
+  transportFactory: () => Transport;  // Factory function returning custom transport
+}
+```
+
+#### Example Usage
+```typescript
+// HTTP/SSE transport configuration
+const httpConfig = {
+  target: {
+    transportType: "httpStream" as const,
+    url: "http://localhost:33000",
+    mcpPath: "/api/mcp"  // Custom endpoint path
+  }
+};
+
+// Custom transport configuration
+const customConfig = {
+  target: {
+    transportType: "custom" as const,
+    transportFactory: () => new MyCustomTransport({
+      endpoint: "ws://localhost:8080",
+      protocols: ["mcp"]
+    })
+  }
+};
+```
+
 ### Advanced Configuration (Legacy API Compatible)
 
 For backward compatibility, the package also exports legacy-style configuration functions:
@@ -211,8 +255,9 @@ const proxy = await createPassthroughProxy({
   transportType: "httpStream",
   port: 34000,
   target: {
+    transportType: "httpStream",
     url: "http://localhost:33000",
-    transportType: "httpStream"
+    mcpPath: "/mcp" // Optional, defaults to /mcp
   },
   hooks: [
     { url: "http://localhost:33004", name: "audit-hook" }

--- a/packages/passthrough-mcp-server/examples/hook-api-example.ts
+++ b/packages/passthrough-mcp-server/examples/hook-api-example.ts
@@ -17,6 +17,7 @@ import {
   processRequestThroughHooks,
   processResponseThroughHooks,
 } from "@civic/passthrough-mcp-server";
+import { logger } from "../src/logger/logger.js";
 
 /**
  * Example: Create a validation hook using AbstractHook
@@ -71,7 +72,7 @@ async function processToolCallWithHooks(
   >(toolCall, hooks, "processToolCallRequest");
 
   if (requestResult.resultType === "abort") {
-    console.error("Request rejected:", requestResult.reason);
+    logger.error(`Request rejected: ${requestResult.reason}`);
     return {
       error: requestResult.reason,
       status: "rejected",
@@ -100,7 +101,7 @@ async function processToolCallWithHooks(
   );
 
   if (responseResult.resultType === "abort") {
-    console.error("Response rejected:", responseResult.reason);
+    logger.error(`Response rejected: ${responseResult.reason}`);
     return {
       error: responseResult.reason,
       status: "rejected",
@@ -163,7 +164,7 @@ class ToolService {
 
   private async executeInternal(toolCall: CallToolRequest): Promise<unknown> {
     // Your actual tool execution logic here
-    console.log(`Executing tool: ${toolCall.params.name}`);
+    logger.info(`Executing tool: ${toolCall.params.name}`);
     return {
       content: [
         {
@@ -177,7 +178,7 @@ class ToolService {
 
 // Helper function to simulate tool execution
 async function executeToolCall(toolCall: CallToolRequest): Promise<unknown> {
-  console.log(`Executing tool: ${toolCall.params.name}`);
+  logger.info(`Executing tool: ${toolCall.params.name}`);
 
   // Simulate different tool responses
   switch (toolCall.params.name) {
@@ -226,7 +227,7 @@ async function executeToolCall(toolCall: CallToolRequest): Promise<unknown> {
 // Example usage
 async function main() {
   // Example 1: Direct usage
-  console.log("=== Example 1: Direct Usage ===");
+  logger.info("=== Example 1: Direct Usage ===");
   const searchCall: CallToolRequest = {
     method: "tools/call",
     params: {
@@ -236,10 +237,10 @@ async function main() {
   };
 
   const result1 = await processToolCallWithHooks(searchCall);
-  console.log("Search result:", result1);
+  logger.info(`Search result: ${JSON.stringify(result1)}`);
 
   // Example 2: Forbidden tool
-  console.log("\n=== Example 2: Forbidden Tool ===");
+  logger.info("\n=== Example 2: Forbidden Tool ===");
   const forbiddenCall: CallToolRequest = {
     method: "tools/call",
     params: {
@@ -249,10 +250,10 @@ async function main() {
   };
 
   const result2 = await processToolCallWithHooks(forbiddenCall);
-  console.log("Forbidden result:", result2);
+  logger.info(`Forbidden result: ${JSON.stringify(result2)}`);
 
   // Example 3: Using the service class
-  console.log("\n=== Example 3: Service Class Usage ===");
+  logger.info("\n=== Example 3: Service Class Usage ===");
   const service = new ToolService([
     new ValidationHook(),
     // Add more hooks as needed
@@ -266,13 +267,13 @@ async function main() {
         arguments: { expression: "2 + 2" },
       },
     });
-    console.log("Calculation result:", result3);
+    logger.info(`Calculation result: ${JSON.stringify(result3)}`);
   } catch (error) {
-    console.error("Service error:", error);
+    logger.error(`Service error: ${error}`);
   }
 }
 
 // Run the example
 if (import.meta.url === `file://${process.argv[1]}`) {
-  main().catch(console.error);
+  main().catch((err) => logger.error(String(err)));
 }

--- a/packages/passthrough-mcp-server/examples/programmatic-usage.ts
+++ b/packages/passthrough-mcp-server/examples/programmatic-usage.ts
@@ -114,7 +114,7 @@ async function example4_withProgrammaticHooks() {
       );
       return {
         resultType: "continue",
-        response: response,
+        response,
       };
     }
   }
@@ -169,7 +169,9 @@ async function example4_withProgrammaticHooks() {
 }
 
 async function example5_stdioProxy() {
-  console.log("\nExample 5: Stdio Proxy");
+  // Note: When using stdio transport, all logging is sent to stderr
+  // to avoid interfering with the stdio protocol communication
+  console.error("\nExample 5: Stdio Proxy");
 
   // Example of stdio proxy (useful for direct command-line integration)
   const proxy = await createPassthroughProxy({
@@ -180,8 +182,9 @@ async function example5_stdioProxy() {
     },
   });
 
-  console.log("Stdio proxy is running!");
-  console.log("The proxy will forward stdio input/output to the HTTP target");
+  // These messages are sent to stderr when using stdio transport
+  console.error("Stdio proxy is running!");
+  console.error("The proxy will forward stdio input/output to the HTTP target");
 }
 
 // Run examples based on command line argument

--- a/packages/passthrough-mcp-server/examples/programmatic-usage.ts
+++ b/packages/passthrough-mcp-server/examples/programmatic-usage.ts
@@ -13,9 +13,10 @@ import {
   type ToolCallResponseHookResult,
 } from "@civic/hook-common";
 import { createPassthroughProxy } from "../src/index.js";
+import { logger } from "../src/logger/logger.js";
 
 async function example1_basicUsage() {
-  console.log("Example 1: Basic Usage");
+  logger.info("Example 1: Basic Usage");
 
   // Create and start the proxy
   const proxy = await createPassthroughProxy({
@@ -27,17 +28,17 @@ async function example1_basicUsage() {
     },
   });
 
-  console.log("Passthrough proxy is running!");
+  logger.info("Passthrough proxy is running!");
 
   // Stop after 10 seconds
   setTimeout(async () => {
     await proxy.stop();
-    console.log("Proxy stopped");
+    logger.info("Proxy stopped");
   }, 10000);
 }
 
 async function example2_manualStart() {
-  console.log("\nExample 2: Manual Start");
+  logger.info("\nExample 2: Manual Start");
 
   // Create without auto-starting
   const proxy = await createPassthroughProxy({
@@ -50,16 +51,16 @@ async function example2_manualStart() {
     autoStart: false,
   });
 
-  console.log("Proxy created but not started");
+  logger.info("Proxy created but not started");
 
   // Start manually after some setup
-  console.log("Starting proxy...");
+  logger.info("Starting proxy...");
   await proxy.start();
-  console.log("Proxy is now running!");
+  logger.info("Proxy is now running!");
 }
 
 async function example3_withRemoteHooks() {
-  console.log("\nExample 3: With Remote Hooks");
+  logger.info("\nExample 3: With Remote Hooks");
 
   const proxy = await createPassthroughProxy({
     sourceTransportType: "httpStream",
@@ -79,11 +80,11 @@ async function example3_withRemoteHooks() {
       },
     ],
   });
-  console.log("Proxy running with remote hooks configured");
+  logger.info("Proxy running with remote hooks configured");
 }
 
 async function example4_withProgrammaticHooks() {
-  console.log("\nExample 4: With Programmatic Hooks");
+  logger.info("\nExample 4: With Programmatic Hooks");
 
   // Create a simple logging hook
   class LoggingHook extends AbstractHook {
@@ -94,9 +95,8 @@ async function example4_withProgrammaticHooks() {
     async processToolCallRequest(
       toolCall: CallToolRequest,
     ): Promise<ToolCallRequestHookResult> {
-      console.log(
-        `[${this.name}] Tool request: ${toolCall.params.name}`,
-        toolCall.params.arguments,
+      logger.info(
+        `[${this.name}] Tool request: ${toolCall.params.name} ${JSON.stringify(toolCall.params.arguments)}`,
       );
       return {
         resultType: "continue",
@@ -108,9 +108,8 @@ async function example4_withProgrammaticHooks() {
       response: CallToolResult,
       originalToolCall: CallToolRequest,
     ): Promise<ToolCallResponseHookResult> {
-      console.log(
-        `[${this.name}] Tool response for ${originalToolCall.params.name}:`,
-        response,
+      logger.info(
+        `[${this.name}] Tool response for ${originalToolCall.params.name}: ${JSON.stringify(response)}`,
       );
       return {
         resultType: "continue",
@@ -165,13 +164,13 @@ async function example4_withProgrammaticHooks() {
     ],
   });
 
-  console.log("Proxy running with both programmatic and remote hooks");
+  logger.info("Proxy running with both programmatic and remote hooks");
 }
 
 async function example5_stdioProxy() {
   // Note: When using stdio transport, all logging is sent to stderr
   // to avoid interfering with the stdio protocol communication
-  console.error("\nExample 5: Stdio Proxy");
+  logger.info("\nExample 5: Stdio Proxy");
 
   // Example of stdio proxy (useful for direct command-line integration)
   const proxy = await createPassthroughProxy({
@@ -183,8 +182,8 @@ async function example5_stdioProxy() {
   });
 
   // These messages are sent to stderr when using stdio transport
-  console.error("Stdio proxy is running!");
-  console.error("The proxy will forward stdio input/output to the HTTP target");
+  logger.info("Stdio proxy is running!");
+  logger.info("The proxy will forward stdio input/output to the HTTP target");
 }
 
 // Run examples based on command line argument
@@ -192,25 +191,25 @@ const exampleNumber = process.argv[2] || "1";
 
 switch (exampleNumber) {
   case "1":
-    example1_basicUsage().catch(console.error);
+    example1_basicUsage().catch((err) => logger.error(String(err)));
     break;
   case "2":
-    example2_manualStart().catch(console.error);
+    example2_manualStart().catch((err) => logger.error(String(err)));
     break;
   case "3":
-    example3_withRemoteHooks().catch(console.error);
+    example3_withRemoteHooks().catch((err) => logger.error(String(err)));
     break;
   case "4":
-    example4_withProgrammaticHooks().catch(console.error);
+    example4_withProgrammaticHooks().catch((err) => logger.error(String(err)));
     break;
   case "5":
-    example5_stdioProxy().catch(console.error);
+    example5_stdioProxy().catch((err) => logger.error(String(err)));
     break;
   default:
-    console.log("Usage: tsx programmatic-usage.ts [1|2|3|4|5]");
-    console.log("1 - Basic usage");
-    console.log("2 - Manual start");
-    console.log("3 - With remote hooks");
-    console.log("4 - With programmatic hooks");
-    console.log("5 - Stdio proxy");
+    logger.info("Usage: tsx programmatic-usage.ts [1|2|3|4|5]");
+    logger.info("1 - Basic usage");
+    logger.info("2 - Manual start");
+    logger.info("3 - With remote hooks");
+    logger.info("4 - With programmatic hooks");
+    logger.info("5 - Stdio proxy");
 }

--- a/packages/passthrough-mcp-server/examples/request-manipulation-hook.ts
+++ b/packages/passthrough-mcp-server/examples/request-manipulation-hook.ts
@@ -20,6 +20,7 @@ import {
   type ToolCallRequestHookResult,
   type ToolCallResponseHookResult,
 } from "@civic/hook-common";
+import { logger } from "../src/logger/logger.js";
 
 /**
  * Example 1: Authentication Header Hook
@@ -101,7 +102,7 @@ export class ConditionalRoutingHook extends AbstractHook {
     const targetHost = this.routingRules[toolName];
 
     if (targetHost) {
-      console.log(`Routing tool ${toolName} to ${targetHost}`);
+      logger.info(`Routing tool ${toolName} to ${targetHost}`);
       return {
         resultType: "continue",
         request,
@@ -146,7 +147,7 @@ export class PathRewritingHook extends AbstractHook {
     for (const mapping of this.pathMappings) {
       if (mapping.from.test(modifiedPath)) {
         modifiedPath = modifiedPath.replace(mapping.from, mapping.to);
-        console.log(
+        logger.info(
           `Rewriting path from ${request.req.path} to ${modifiedPath}`,
         );
         break;
@@ -273,8 +274,8 @@ export class CombinedManipulationHook extends AbstractHook {
 
 // Example usage
 async function main() {
-  console.log("Request Manipulation Hook Examples");
-  console.log("=================================");
+  logger.info("Request Manipulation Hook Examples");
+  logger.info("=================================");
 
   // Example 1: Authentication
   const authHook = new AuthenticationHeaderHook("sk-test-12345");
@@ -292,7 +293,7 @@ async function main() {
   };
 
   const authResult = await authHook.processToolCallRequest(authRequest);
-  console.log("\nAuth Hook Result:", JSON.stringify(authResult, null, 2));
+  logger.info(`\nAuth Hook Result: ${JSON.stringify(authResult, null, 2)}`);
 
   // Example 2: Conditional Routing
   const routingHook = new ConditionalRoutingHook({
@@ -316,7 +317,9 @@ async function main() {
 
   const routingResult =
     await routingHook.processToolCallRequest(routingRequest);
-  console.log("\nRouting Hook Result:", JSON.stringify(routingResult, null, 2));
+  logger.info(
+    `\nRouting Hook Result: ${JSON.stringify(routingResult, null, 2)}`,
+  );
 
   // Example 3: Path Rewriting
   const pathHook = new PathRewritingHook([
@@ -338,7 +341,7 @@ async function main() {
   };
 
   const pathResult = await pathHook.processToolCallRequest(pathRequest);
-  console.log("\nPath Hook Result:", JSON.stringify(pathResult, null, 2));
+  logger.info(`\nPath Hook Result: ${JSON.stringify(pathResult, null, 2)}`);
 
   // Example 4: Header Filtering
   const filterHook = new HeaderFilteringHook([
@@ -366,10 +369,10 @@ async function main() {
   };
 
   const filterResult = await filterHook.processToolCallRequest(filterRequest);
-  console.log("\nFilter Hook Result:", JSON.stringify(filterResult, null, 2));
+  logger.info(`\nFilter Hook Result: ${JSON.stringify(filterResult, null, 2)}`);
 }
 
 // Run examples if this file is executed directly
 if (import.meta.url === `file://${process.argv[1]}`) {
-  main().catch(console.error);
+  main().catch((err) => logger.error(String(err)));
 }

--- a/packages/passthrough-mcp-server/src/hook/processor.ts
+++ b/packages/passthrough-mcp-server/src/hook/processor.ts
@@ -23,6 +23,7 @@ import type {
   MethodsWithTransportErrorType,
   TransportError,
 } from "@civic/hook-common";
+import { logger } from "../logger/logger.js";
 import type { LinkedListHook } from "./hookChain.js";
 
 /**
@@ -56,7 +57,7 @@ export async function processRequestThroughHooks<
   let currentRequest = request;
   let currentHook = head;
 
-  console.log(
+  logger.debug(
     `[Processor] Processing request through hooks for method ${methodName}`,
   );
   while (currentHook) {
@@ -68,13 +69,13 @@ export async function processRequestThroughHooks<
     // - A hook might not implement every possible method
     // - TypeScript ensures methodName is valid, but not that every hook has it
     if (!hookMethod || typeof hookMethod !== "function") {
-      console.log(
+      logger.debug(
         `[Processor] Skipping hook ${hook.name} - no method ${methodName}`,
       );
       continue;
     }
 
-    console.log(`Processing hook ${hook.name} for method ${methodName}`);
+    logger.debug(`Processing hook ${hook.name} for method ${methodName}`);
 
     // Why use .call():
     // - Ensures 'this' context is properly bound to the hook instance

--- a/packages/passthrough-mcp-server/src/proxy/config.ts
+++ b/packages/passthrough-mcp-server/src/proxy/config.ts
@@ -11,7 +11,6 @@ import type { Hook } from "@civic/hook-common";
 import type { Transport } from "@modelcontextprotocol/sdk/shared/transport.js";
 import { logger } from "../logger/logger.js";
 
-type TransportType = "httpStream" | "sse" | "custom";
 type SourceTransportType = "stdio" | "httpStream" | "sse" | "custom";
 
 // Base configuration with discriminated union based on transport type
@@ -29,12 +28,16 @@ export type BaseConfig =
       sourceTransport: Transport;
     };
 
-export interface TargetConfig {
-  transportType: TransportType;
-  transportFactory?: () => Transport;
-  url: string;
-  mcpPath?: string; // Path to MCP endpoint on target server, defaults to /mcp
-}
+export type TargetConfig =
+  | {
+      transportType: "httpStream" | "sse";
+      url: string;
+      mcpPath?: string; // Path to MCP endpoint on target server, defaults to /mcp
+    }
+  | {
+      transportType: "custom";
+      transportFactory: () => Transport;
+    };
 
 export interface RemoteHookConfig {
   url: string;

--- a/packages/passthrough-mcp-server/src/proxy/config.ts
+++ b/packages/passthrough-mcp-server/src/proxy/config.ts
@@ -31,7 +31,7 @@ export type BaseConfig =
 
 export interface TargetConfig {
   transportType: TransportType;
-  transport?: Transport;
+  transportFactory?: () => Transport;
   url: string;
   mcpPath?: string; // Path to MCP endpoint on target server, defaults to /mcp
 }

--- a/packages/passthrough-mcp-server/src/proxy/config.ts
+++ b/packages/passthrough-mcp-server/src/proxy/config.ts
@@ -9,7 +9,7 @@
 import * as process from "node:process";
 import type { Hook } from "@civic/hook-common";
 import type { Transport } from "@modelcontextprotocol/sdk/shared/transport.js";
-import { configureLoggerForStdio, logger } from "../logger/logger.js";
+import { logger } from "../logger/logger.js";
 
 type TransportType = "httpStream" | "sse" | "custom";
 type SourceTransportType = "stdio" | "httpStream" | "sse" | "custom";

--- a/packages/passthrough-mcp-server/src/proxy/config.ts
+++ b/packages/passthrough-mcp-server/src/proxy/config.ts
@@ -106,11 +106,6 @@ export function loadConfig(): Config {
   // Server configuration
   const sourceTransportType = parseServerTransport(process.argv);
 
-  // Configure logger for stdio mode to avoid interfering with stdout
-  if (sourceTransportType === "stdio") {
-    configureLoggerForStdio();
-  }
-
   // Target configuration
   const targetUrl = process.env.TARGET_SERVER_URL || "http://localhost:33000";
   const targetTransport = parseClientTransport(process.env);

--- a/packages/passthrough-mcp-server/src/proxy/createProxies.ts
+++ b/packages/passthrough-mcp-server/src/proxy/createProxies.ts
@@ -3,6 +3,7 @@
  */
 
 import type { Transport } from "@modelcontextprotocol/sdk/shared/transport.js";
+import { configureLoggerForStdio } from "../logger/logger.js";
 import type { Config } from "./config.js";
 import { HttpPassthroughProxy } from "./http/httpPassthroughProxy.js";
 import { StdioPassthroughProxy } from "./stdio/stdioPassthroughProxy.js";
@@ -41,6 +42,9 @@ export type CustomProxyConfig = Omit<Config, "sourceTransportType"> & {
 export async function createStdioPassthroughProxy(
   config: StdioProxyConfig,
 ): Promise<StdioPassthroughProxy> {
+  // Configure logger for stdio mode to avoid interfering with stdout
+  configureLoggerForStdio();
+  
   const { autoStart = true, ...proxyConfig } = config;
 
   const fullConfig: Config = {

--- a/packages/passthrough-mcp-server/src/proxy/createProxies.ts
+++ b/packages/passthrough-mcp-server/src/proxy/createProxies.ts
@@ -44,7 +44,7 @@ export async function createStdioPassthroughProxy(
 ): Promise<StdioPassthroughProxy> {
   // Configure logger for stdio mode to avoid interfering with stdout
   configureLoggerForStdio();
-  
+
   const { autoStart = true, ...proxyConfig } = config;
 
   const fullConfig: Config = {

--- a/packages/passthrough-mcp-server/src/proxy/createProxies.ts
+++ b/packages/passthrough-mcp-server/src/proxy/createProxies.ts
@@ -123,7 +123,7 @@ export async function createPassthroughProxy(
     return createHttpPassthroughProxy(config);
   }
   if (sourceTransportType === "custom") {
-    throw new Error("Custom Transport not supported yet.");
+    throw new Error("Custom sourceTransport not supported yet.");
   }
   throw new Error(
     `Unsupported transport type: ${sourceTransportType}. Only stdio and httpStream are supported.`,

--- a/packages/passthrough-mcp-server/src/proxy/http/httpPassthroughProxy.ts
+++ b/packages/passthrough-mcp-server/src/proxy/http/httpPassthroughProxy.ts
@@ -19,7 +19,11 @@ import { logger } from "../../logger/logger.js";
 import { PassthroughContext } from "../../shared/passthroughContext.js";
 import { RequestContextAwareStreamableHTTPClientTransport } from "../../transports/requestContextAwareStreamableHTTPClientTransport.js";
 import type { Config } from "../config.js";
-import { createClientTransport } from "../transportFactory.js";
+import {
+  createClientTransport,
+  getTargetMcpPath,
+  getTargetUrl,
+} from "../transportFactory.js";
 import type { PassthroughProxy } from "../types.js";
 import { createMcpHttpServer } from "./mcpHttpServer.js";
 import { McpSessionManager } from "./mcpSessionManager.js";
@@ -215,8 +219,8 @@ export class HttpPassthroughProxy implements PassthroughProxy {
     // Create HTTP proxy server
     this.httpServer = createMcpHttpServer(
       {
-        targetUrl: this.config.target.url,
-        mcpPath: this.config.target.mcpPath || "/mcp",
+        targetUrl: getTargetUrl(this.config.target),
+        mcpPath: getTargetMcpPath(this.config.target),
       },
       this.handleRequest.bind(this),
     );
@@ -244,7 +248,7 @@ export class HttpPassthroughProxy implements PassthroughProxy {
     this.isStarted = true;
 
     logger.info(
-      `[HttpPassthrough] Passthrough MCP Server running with ${this.config.sourceTransportType} transport on port ${port}, connecting to target at ${this.config.target.url}`,
+      `[HttpPassthrough] Passthrough MCP Server running with ${this.config.sourceTransportType} transport on port ${port}, connecting to target at ${getTargetUrl(this.config.target)}`,
     );
   }
 

--- a/packages/passthrough-mcp-server/src/proxy/http/httpPassthroughProxy.ts
+++ b/packages/passthrough-mcp-server/src/proxy/http/httpPassthroughProxy.ts
@@ -13,7 +13,6 @@ import type {
 
 import { randomUUID } from "node:crypto";
 import { URL } from "node:url";
-import { StreamableHTTPClientTransport } from "@modelcontextprotocol/sdk/client/streamableHttp.js";
 import { StreamableHTTPServerTransport } from "@modelcontextprotocol/sdk/server/streamableHttp.js";
 import { isInitializeRequest } from "@modelcontextprotocol/sdk/types.js";
 import { logger } from "../../logger/logger.js";
@@ -30,8 +29,8 @@ export class HttpPassthroughProxy implements PassthroughProxy {
   private isStarted = false;
   private sessionManager: McpSessionManager;
 
-  private targetUrl: string;
-  private targetMcpPath: string;
+  private readonly targetUrl: string;
+  private readonly targetMcpPath: string;
 
   constructor(private config: Config & { sourceTransportType: "httpStream" }) {
     this.sessionManager = new McpSessionManager();
@@ -231,8 +230,8 @@ export class HttpPassthroughProxy implements PassthroughProxy {
     // Create HTTP proxy server
     this.httpServer = createMcpHttpServer(
       {
-        targetUrl: this.config.target.url,
-        mcpEndpoint: "/mcp",
+        targetUrl: this.targetUrl,
+        mcpPath: this.targetMcpPath,
       },
       this.handleRequest.bind(this),
     );

--- a/packages/passthrough-mcp-server/src/proxy/http/httpPassthroughProxy.ts
+++ b/packages/passthrough-mcp-server/src/proxy/http/httpPassthroughProxy.ts
@@ -56,17 +56,13 @@ export class HttpPassthroughProxy implements PassthroughProxy {
     req: IncomingMessage,
     res: ServerResponse,
   ): Promise<void> {
-    console.log(`Received MCP HTTP request: ${req.method} ${req.url}`);
-    console.log("Headers:", JSON.stringify(req.headers, null, 2));
-
     // Parse the request body
     // biome-ignore lint/suspicious/noExplicitAny: JSON-RPC body structure is dynamic
     let body: any;
     try {
       body = await parseJsonBody(req);
-      console.log("Body:", JSON.stringify(body, null, 2));
     } catch (error) {
-      console.error("Error parsing request body:", error);
+      logger.error(`Error parsing request body: ${error}`);
       res.writeHead(400, { "Content-Type": "application/json" });
       res.end(JSON.stringify({ error: "Invalid request body" }));
       return;
@@ -82,11 +78,11 @@ export class HttpPassthroughProxy implements PassthroughProxy {
       // Store the session
       if (sessionId && serverTransport) {
         // Reuse existing transport
-        console.log(
+        logger.debug(
           `Reusing existing HTTP transport for session ID: ${sessionId}`,
         );
       } else if (!sessionId && isInitializeRequest(body)) {
-        console.log("Initializing new HTTP transport");
+        logger.debug("Initializing new HTTP transport");
         // New Session -> new transports and passthrough Context
         const proxyContext = new PassthroughContext(this.config.hooks);
 
@@ -108,7 +104,7 @@ export class HttpPassthroughProxy implements PassthroughProxy {
           onsessioninitialized: (newSessionId) => {
             // Store the transport by session ID
             this.sessionManager.addSession(newSessionId, proxyContext);
-            console.log(
+            logger.debug(
               `HTTP transport initialized for session: ${newSessionId}`,
             );
           },
@@ -117,7 +113,7 @@ export class HttpPassthroughProxy implements PassthroughProxy {
         // Clean up transport when closed
         serverTransport.onclose = () => {
           if (serverTransport?.sessionId) {
-            console.log(
+            logger.debug(
               `HTTP Streaming connection closed for session ${serverTransport.sessionId}`,
             );
             // Remove the session from the session manager, but do not cascade close the transport
@@ -127,10 +123,10 @@ export class HttpPassthroughProxy implements PassthroughProxy {
 
         // Connect the MCP server to this transport
         await proxyContext.connect(serverTransport, clientTransport);
-        console.log("New MCP HTTP connection established");
+        logger.debug("New MCP HTTP connection established");
       } else {
         // Invalid request
-        console.error(
+        logger.error(
           "Invalid MCP HTTP request: No valid session ID provided or not an initialize request",
         );
         res.writeHead(400, { "Content-Type": "application/json" });
@@ -150,7 +146,7 @@ export class HttpPassthroughProxy implements PassthroughProxy {
 
       // Ensure we have a valid transport before handling the request
       if (!serverTransport) {
-        console.error("Transport not available for MCP HTTP request");
+        logger.error("Transport not available for MCP HTTP request");
         res.writeHead(400, { "Content-Type": "application/json" });
         res.end(
           JSON.stringify({
@@ -168,7 +164,7 @@ export class HttpPassthroughProxy implements PassthroughProxy {
       // Handle the request
       await serverTransport.handleRequest(req, res, body);
     } catch (error) {
-      console.error("Error handling MCP HTTP request:", error);
+      logger.error(`Error handling MCP HTTP request: ${error}`);
       if (!res.headersSent) {
         res.writeHead(500, { "Content-Type": "application/json" });
         res.end(JSON.stringify({ error: "Failed to process HTTP request" }));
@@ -181,9 +177,6 @@ export class HttpPassthroughProxy implements PassthroughProxy {
     res: ServerResponse,
   ): Promise<void> {
     try {
-      console.log(`Received MCP HTTP request: ${req.method} ${req.url}`);
-      console.log("Headers:", JSON.stringify(req.headers, null, 2));
-
       const sessionId = req.headers["mcp-session-id"] as string | undefined;
 
       if (!sessionId) {
@@ -214,7 +207,7 @@ export class HttpPassthroughProxy implements PassthroughProxy {
           .passthroughServerTransport as StreamableHTTPServerTransport
       ).handleRequest(req, res);
     } catch (error) {
-      console.error("Error handling MCP HTTP GET/DELETE request:", error);
+      logger.error(`Error handling MCP HTTP GET/DELETE request: ${error}`);
       if (!res.headersSent) {
         res.writeHead(500, { "Content-Type": "application/json" });
         res.end(

--- a/packages/passthrough-mcp-server/src/proxy/http/mcpHttpServer.ts
+++ b/packages/passthrough-mcp-server/src/proxy/http/mcpHttpServer.ts
@@ -16,7 +16,7 @@ import { logger } from "../../logger/logger.js";
 
 export interface ProxyOptions {
   targetUrl: string;
-  mcpEndpoint?: string; // defaults to /mcp
+  mcpPath: string;
 }
 
 /**
@@ -29,13 +29,12 @@ export function createMcpHttpServer(
   mcpHandler: (req: IncomingMessage, res: ServerResponse) => Promise<void>,
 ): http.Server {
   const targetUrl = new URL(options.targetUrl);
-  const mcpEndpoint = options.mcpEndpoint || "/mcp";
 
   return http.createServer(async (req, res) => {
     const requestUrl = new URL(req.url || "/", `http://${req.headers.host}`);
 
     // Route based on path
-    if (requestUrl.pathname === mcpEndpoint) {
+    if (requestUrl.pathname === options.mcpPath) {
       // Handle MCP requests
       await mcpHandler(req, res);
     } else {

--- a/packages/passthrough-mcp-server/src/proxy/stdio/stdioPassthroughProxy.ts
+++ b/packages/passthrough-mcp-server/src/proxy/stdio/stdioPassthroughProxy.ts
@@ -21,12 +21,10 @@ export class StdioPassthroughProxy implements PassthroughProxy {
 
   constructor(private config: Config & { sourceTransportType: "stdio" }) {
     this.serverTransport = new StdioServerTransport();
-
     this.clientTransport = createClientTransport(
-      config.target,
-      config.authToken,
+      this.config.target,
+      this.config.authToken,
     );
-
     this.proxyContext = new PassthroughContext(config.hooks);
   }
 

--- a/packages/passthrough-mcp-server/src/proxy/stdio/stdioPassthroughProxy.ts
+++ b/packages/passthrough-mcp-server/src/proxy/stdio/stdioPassthroughProxy.ts
@@ -9,7 +9,7 @@ import type { Transport } from "@modelcontextprotocol/sdk/shared/transport.js";
 import { logger } from "../../logger/logger.js";
 import { PassthroughContext } from "../../shared/passthroughContext.js";
 import type { Config } from "../config.js";
-import { createClientTransport } from "../transportFactory.js";
+import { createClientTransport, getTargetUrl } from "../transportFactory.js";
 import type { PassthroughProxy } from "../types.js";
 
 export class StdioPassthroughProxy implements PassthroughProxy {
@@ -46,7 +46,7 @@ export class StdioPassthroughProxy implements PassthroughProxy {
     this.isStarted = true;
 
     logger.info(
-      `[StdioPassthrough] Passthrough MCP Server running with stdio transport, connecting to target at ${this.config.target.url}`,
+      `[StdioPassthrough] Passthrough MCP Server running with stdio transport, connecting to target at ${getTargetUrl(this.config.target)}`,
     );
   }
 

--- a/packages/passthrough-mcp-server/src/proxy/stdio/stdioPassthroughProxy.ts
+++ b/packages/passthrough-mcp-server/src/proxy/stdio/stdioPassthroughProxy.ts
@@ -4,37 +4,29 @@
  * Provides a stdio transport that forwards messages to a remote server
  */
 
-import { URL } from "node:url";
-import { StreamableHTTPClientTransport } from "@modelcontextprotocol/sdk/client/streamableHttp.js";
 import { StdioServerTransport } from "@modelcontextprotocol/sdk/server/stdio.js";
+import type { Transport } from "@modelcontextprotocol/sdk/shared/transport.js";
 import { logger } from "../../logger/logger.js";
 import { PassthroughContext } from "../../shared/passthroughContext.js";
 import type { Config } from "../config.js";
+import { createClientTransport } from "../transportFactory.js";
 import type { PassthroughProxy } from "../types.js";
 
 export class StdioPassthroughProxy implements PassthroughProxy {
   private isStarted = false;
-  private targetUrl: string;
-  private targetMcpPath: string;
 
   private proxyContext: PassthroughContext;
   private serverTransport: StdioServerTransport;
-  private clientTransport: StreamableHTTPClientTransport;
+  private clientTransport: Transport;
 
   constructor(private config: Config & { sourceTransportType: "stdio" }) {
     this.serverTransport = new StdioServerTransport();
-    this.targetUrl = config.target.url;
-    this.targetMcpPath = config.target.mcpPath || "/mcp";
-    this.clientTransport = new StreamableHTTPClientTransport(
-      new URL(this.targetUrl + this.targetMcpPath),
-      {
-        requestInit: {
-          headers: config.authToken
-            ? { Authorization: `Bearer ${config.authToken}` }
-            : undefined,
-        },
-      },
+
+    this.clientTransport = createClientTransport(
+      config.target,
+      config.authToken,
     );
+
     this.proxyContext = new PassthroughContext(config.hooks);
   }
 

--- a/packages/passthrough-mcp-server/src/proxy/transportFactory.ts
+++ b/packages/passthrough-mcp-server/src/proxy/transportFactory.ts
@@ -23,10 +23,10 @@ export function createClientTransport(
   customHeaders?: Record<string, string>,
 ): Transport {
   if (targetConfig.transportType === "custom") {
-    if (!targetConfig.transport) {
-      throw new Error("Custom transport is not defined");
+    if (!targetConfig.transportFactory) {
+      throw new Error("Custom transport factory is not defined");
     }
-    return targetConfig.transport;
+    return targetConfig.transportFactory();
   }
 
   if (targetConfig.transportType === "httpStream") {

--- a/packages/passthrough-mcp-server/src/proxy/transportFactory.ts
+++ b/packages/passthrough-mcp-server/src/proxy/transportFactory.ts
@@ -1,0 +1,57 @@
+/**
+ * Transport Factory Module
+ *
+ * Provides helper functions for creating client transports based on configuration.
+ * This ensures consistent transport creation across different proxy implementations.
+ */
+
+import { URL } from "node:url";
+import type { Transport } from "@modelcontextprotocol/sdk/shared/transport.js";
+import { RequestContextAwareStreamableHTTPClientTransport } from "../transports/requestContextAwareStreamableHTTPClientTransport.js";
+import type { TargetConfig } from "./config.js";
+
+/**
+ * Creates a client transport based on the target configuration
+ * @param targetConfig - Target server configuration
+ * @param authToken - Optional auth token for HTTP requests
+ * @param customHeaders - Optional custom headers to include
+ * @returns Configured transport instance
+ */
+export function createClientTransport(
+  targetConfig: TargetConfig,
+  authToken?: string,
+  customHeaders?: Record<string, string>,
+): Transport {
+  if (targetConfig.transportType === "custom") {
+    if (!targetConfig.transport) {
+      throw new Error("Custom transport is not defined");
+    }
+    return targetConfig.transport;
+  }
+
+  if (targetConfig.transportType === "httpStream") {
+    const targetMcpPath = targetConfig.mcpPath || "/mcp";
+    const url = new URL(targetConfig.url + targetMcpPath);
+
+    // Build headers from authToken and customHeaders
+    const headers: Record<string, string> = {};
+    if (authToken) {
+      headers.Authorization = `Bearer ${authToken}`;
+    }
+    if (customHeaders) {
+      Object.assign(headers, customHeaders);
+    }
+
+    const options = {
+      requestInit: {
+        headers: Object.keys(headers).length > 0 ? headers : undefined,
+      },
+    };
+
+    return new RequestContextAwareStreamableHTTPClientTransport(url, options);
+  }
+
+  throw new Error(
+    `Unsupported Client Transport Type: ${targetConfig.transportType}. Supported types: httpStream, custom.`,
+  );
+}

--- a/packages/passthrough-mcp-server/src/proxy/transportFactory.ts
+++ b/packages/passthrough-mcp-server/src/proxy/transportFactory.ts
@@ -11,6 +11,26 @@ import { RequestContextAwareStreamableHTTPClientTransport } from "../transports/
 import type { TargetConfig } from "./config.js";
 
 /**
+ * Helper function to get URL from target config safely
+ */
+export function getTargetUrl(targetConfig: TargetConfig): string {
+  if (targetConfig.transportType === "custom") {
+    throw new Error("URL not available for custom transport type");
+  }
+  return targetConfig.url;
+}
+
+/**
+ * Helper function to get MCP path from target config safely
+ */
+export function getTargetMcpPath(targetConfig: TargetConfig): string {
+  if (targetConfig.transportType === "custom") {
+    throw new Error("MCP path not available for custom transport type");
+  }
+  return targetConfig.mcpPath || "/mcp";
+}
+
+/**
  * Creates a client transport based on the target configuration
  * @param targetConfig - Target server configuration
  * @param authToken - Optional auth token for HTTP requests
@@ -23,13 +43,15 @@ export function createClientTransport(
   customHeaders?: Record<string, string>,
 ): Transport {
   if (targetConfig.transportType === "custom") {
-    if (!targetConfig.transportFactory) {
-      throw new Error("Custom transport factory is not defined");
-    }
+    // TypeScript now knows transportFactory is definitely present
     return targetConfig.transportFactory();
   }
 
-  if (targetConfig.transportType === "httpStream") {
+  if (
+    targetConfig.transportType === "httpStream" ||
+    targetConfig.transportType === "sse"
+  ) {
+    // TypeScript now knows url and mcpPath are definitely present
     const targetMcpPath = targetConfig.mcpPath || "/mcp";
     const url = new URL(targetConfig.url + targetMcpPath);
 

--- a/packages/passthrough-mcp-server/tsconfig.json
+++ b/packages/passthrough-mcp-server/tsconfig.json
@@ -16,6 +16,7 @@
     "**/*.test.ts",
     "**/*.test.js",
     "test/**/*",
-    "examples/**/*"
+    "examples/**/*",
+    "src/integration-tests/**/*"
   ]
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -292,31 +292,6 @@ importers:
         specifier: ^3.2.4
         version: 3.2.4(@types/node@24.1.0)(tsx@4.20.3)
 
-  packages/passthrough-mcp-server-legacy:
-    dependencies:
-      '@civic/hook-common':
-        specifier: workspace:^
-        version: link:../hook-common
-      '@modelcontextprotocol/sdk':
-        specifier: ^1.17.1
-        version: 1.17.1
-    devDependencies:
-      '@types/node':
-        specifier: ^20.10.0
-        version: 20.19.9
-      '@vitest/coverage-v8':
-        specifier: ^2.1.8
-        version: 2.1.9(vitest@2.1.9(@types/node@20.19.9))
-      tsx:
-        specifier: ^4.20.3
-        version: 4.20.3
-      typescript:
-        specifier: ^5.2.2
-        version: 5.8.3
-      vitest:
-        specifier: ^2.1.8
-        version: 2.1.9(@types/node@20.19.9)
-
   packages/rate-limit-hook:
     dependencies:
       '@civic/hook-common':

--- a/test/integration/test-config.ts
+++ b/test/integration/test-config.ts
@@ -19,7 +19,7 @@ export const TEST_CONFIG = {
   },
   passthroughServers: {
     withoutAuth: {
-      url: "http://localhost:34000/mcp",
+      url: "http://localhost:34000/stream",
       description: "Passthrough server pointing to target without auth",
     },
     withAuth: {
@@ -31,7 +31,7 @@ export const TEST_CONFIG = {
       description: "Passthrough server pointing to echo test server",
     },
     withHooks: {
-      url: "http://localhost:34200/mcp",
+      url: "http://localhost:34200/stream",
       description: "Passthrough server with explain hook pointing to fetchDocs",
     },
     programmatic: {


### PR DESCRIPTION
## Summary

This PR includes several improvements and refactoring changes to the passthrough-mcp-server:

- **Fix stdio logger configuration**: Configure logger for stdio when using `createStdioPassthroughProxy` programmatically to prevent console.log interference with stdio communication
- **Use configurable mcpPath**: Replace hardcoded `/mcp` endpoint with configurable `mcpPath` from target config
- **Replace console with logger**: Replace all direct console usage with the logger module throughout the codebase for consistent logging
- **Create transport factory helper**: Add centralized `transportFactory.ts` for consistent client transport creation across proxy implementations
- **Update transport factory interface**: Change `TargetConfig` to use synchronous `transportFactory` function instead of direct transport instances
- **Exclude integration-tests from build**: Update tsconfig to exclude integration-tests from dist output

## Test plan

- [x] All TypeScript compilation passes
- [x] Linting passes without errors
- [x] Existing functionality maintained
- [x] Transport creation works consistently across stdio and HTTP proxies