### PR TITLE
fix: handle custom transport types in passthrough proxies

### DIFF
--- a/packages/passthrough-mcp-server/src/proxy/http/httpPassthroughProxy.ts
+++ b/packages/passthrough-mcp-server/src/proxy/http/httpPassthroughProxy.ts
@@ -217,11 +217,19 @@ export class HttpPassthroughProxy implements PassthroughProxy {
 
   async initialize(): Promise<void> {
     // Create HTTP proxy server
+    const proxyOptions =
+      this.config.target.transportType === "custom"
+        ? {
+            targetUrl: undefined,
+            mcpPath: "/mcp", // Default MCP path for custom transports
+          }
+        : {
+            targetUrl: getTargetUrl(this.config.target),
+            mcpPath: getTargetMcpPath(this.config.target),
+          };
+
     this.httpServer = createMcpHttpServer(
-      {
-        targetUrl: getTargetUrl(this.config.target),
-        mcpPath: getTargetMcpPath(this.config.target),
-      },
+      proxyOptions,
       this.handleRequest.bind(this),
     );
   }
@@ -247,8 +255,13 @@ export class HttpPassthroughProxy implements PassthroughProxy {
 
     this.isStarted = true;
 
+    const targetInfo =
+      this.config.target.transportType === "custom"
+        ? "custom transport"
+        : `${getTargetUrl(this.config.target)}`;
+
     logger.info(
-      `[HttpPassthrough] Passthrough MCP Server running with ${this.config.sourceTransportType} transport on port ${port}, connecting to target at ${getTargetUrl(this.config.target)}`,
+      `[HttpPassthrough] Passthrough MCP Server running with ${this.config.sourceTransportType} transport on port ${port}, connecting to target at ${targetInfo}`,
     );
   }
 

--- a/packages/passthrough-mcp-server/src/proxy/stdio/stdioPassthroughProxy.ts
+++ b/packages/passthrough-mcp-server/src/proxy/stdio/stdioPassthroughProxy.ts
@@ -45,8 +45,13 @@ export class StdioPassthroughProxy implements PassthroughProxy {
 
     this.isStarted = true;
 
+    const targetInfo =
+      this.config.target.transportType === "custom"
+        ? "custom transport"
+        : `${getTargetUrl(this.config.target)}`;
+
     logger.info(
-      `[StdioPassthrough] Passthrough MCP Server running with stdio transport, connecting to target at ${getTargetUrl(this.config.target)}`,
+      `[StdioPassthrough] Passthrough MCP Server running with stdio transport, connecting to target at ${targetInfo}`,
     );
   }
 


### PR DESCRIPTION
## Summary
- Fixed error "URL not available for custom transport type" when using custom transports with passthrough proxies
- Both StdioPassthroughProxy and HttpPassthroughProxy now properly support custom transport configurations

## Changes
- Updated `StdioPassthroughProxy` to conditionally display "custom transport" in logs instead of trying to get URL
- Updated `HttpPassthroughProxy` to:
  - Conditionally get target URL/path only for non-custom transports
  - Pass undefined targetUrl to mcpHttpServer for custom transports
  - Display "custom transport" in logs
- Made `targetUrl` optional in `mcpHttpServer` ProxyOptions interface
- Added handling in `createMcpHttpServer` to return 404 for non-MCP paths when no target URL is configured

## Test plan
- [x] All existing tests pass
- [x] Linting passes
- [x] Custom transport can be used without throwing errors