### PR TITLE
feat: restructure Config interface with nested source/target objects

### DIFF
--- a/packages/passthrough-mcp-server/CHANGELOG.md
+++ b/packages/passthrough-mcp-server/CHANGELOG.md
@@ -7,6 +7,48 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.7.1] - 2025-08-13
+
+### Changed
+
+- **BREAKING**: Updated Config interface structure to use nested `source` and `target` objects
+  - `sourceTransportType` is now `source.transportType`
+  - HTTP-specific properties (`port`, `mcpPath`, `transportFactory`) now nested under `source`
+  - Cleaner separation between source and target configuration
+- Updated `createPassthroughProxy` to use unified interface with new Config structure
+- Enhanced type definitions with separate `HttpProxyConfig` and `StdioProxyConfig` types
+- Updated all examples and integration tests to use new interface
+
+### Migration Guide
+
+**Before (0.7.0):**
+```typescript
+const proxy = await createPassthroughProxy({
+  sourceTransportType: "httpStream",
+  port: 3000,
+  sourceMcpPath: "/mcp",
+  target: {
+    url: "http://localhost:3001",
+    transportType: "httpStream"
+  }
+});
+```
+
+**After (0.7.1):**
+```typescript
+const proxy = await createPassthroughProxy({
+  source: {
+    transportType: "httpStream",
+    port: 3000,
+    mcpPath: "/mcp"
+  },
+  target: {
+    url: "http://localhost:3001", 
+    transportType: "httpStream"
+  }
+});
+```
+
 ## [0.7.0] - 2025-08-13
 
 ### Added

--- a/packages/passthrough-mcp-server/examples/programmatic-usage.ts
+++ b/packages/passthrough-mcp-server/examples/programmatic-usage.ts
@@ -20,8 +20,10 @@ async function example1_basicUsage() {
 
   // Create and start the proxy
   const proxy = await createPassthroughProxy({
-    sourceTransportType: "httpStream",
-    port: 34000,
+    source: {
+      transportType: "httpStream",
+      port: 34000,
+    },
     target: {
       url: "http://localhost:33000",
       transportType: "httpStream",
@@ -42,8 +44,10 @@ async function example2_manualStart() {
 
   // Create without auto-starting
   const proxy = await createPassthroughProxy({
-    sourceTransportType: "httpStream",
-    port: 34001,
+    source: {
+      transportType: "httpStream",
+      port: 34001,
+    },
     target: {
       url: "http://localhost:33001",
       transportType: "httpStream",
@@ -63,8 +67,10 @@ async function example3_withRemoteHooks() {
   logger.info("\nExample 3: With Remote Hooks");
 
   const proxy = await createPassthroughProxy({
-    sourceTransportType: "httpStream",
-    port: 34002,
+    source: {
+      transportType: "httpStream",
+      port: 34002,
+    },
     target: {
       url: "http://localhost:33002",
       transportType: "httpStream",
@@ -147,8 +153,10 @@ async function example4_withProgrammaticHooks() {
 
   // Mix programmatic hooks with remote hooks
   const proxy = await createPassthroughProxy({
-    sourceTransportType: "httpStream",
-    port: 34002,
+    source: {
+      transportType: "httpStream",
+      port: 34002,
+    },
     target: {
       url: "http://localhost:33002",
       transportType: "httpStream",
@@ -174,7 +182,9 @@ async function example5_stdioProxy() {
 
   // Example of stdio proxy (useful for direct command-line integration)
   const proxy = await createPassthroughProxy({
-    sourceTransportType: "stdio",
+    source: {
+      transportType: "stdio",
+    },
     target: {
       url: "http://localhost:33003",
       transportType: "httpStream",

--- a/packages/passthrough-mcp-server/package.json
+++ b/packages/passthrough-mcp-server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@civic/passthrough-mcp-server",
-  "version": "0.7.0",
+  "version": "0.7.1",
   "description": "A Model Context Protocol (MCP) server that acts as a passthrough proxy with hook middleware support",
   "keywords": [
     "mcp",

--- a/packages/passthrough-mcp-server/src/cli.ts
+++ b/packages/passthrough-mcp-server/src/cli.ts
@@ -9,10 +9,7 @@
 
 import { logger } from "./logger/logger.js";
 import { loadConfig } from "./proxy/config.js";
-import {
-  createHttpPassthroughProxy,
-  createStdioPassthroughProxy,
-} from "./proxy/createProxies.js";
+import { createPassthroughProxy } from "./proxy/createProxies.js";
 import type { PassthroughProxy } from "./proxy/types.js";
 
 /**
@@ -23,23 +20,11 @@ async function main() {
     // Load configuration
     const config = loadConfig();
 
-    // Create and start the passthrough proxy based on transport type
-    let proxy: PassthroughProxy;
-    if (config.sourceTransportType === "stdio") {
-      proxy = await createStdioPassthroughProxy({
-        ...config,
-        autoStart: true,
-      });
-    } else if (config.sourceTransportType === "httpStream") {
-      proxy = await createHttpPassthroughProxy({
-        ...config,
-        port: config.port || 3000,
-        autoStart: true,
-      });
-    } else {
-      // This should never happen due to type checking, but included for safety
-      throw new Error("Source Transport Type not supported");
-    }
+    // Create and start the passthrough proxy
+    const proxy = await createPassthroughProxy({
+      ...config,
+      autoStart: true,
+    });
 
     // Handle graceful shutdown
     const shutdown = async () => {

--- a/packages/passthrough-mcp-server/src/hook/manager.test.ts
+++ b/packages/passthrough-mcp-server/src/hook/manager.test.ts
@@ -25,8 +25,7 @@ describe("Hook Manager", () => {
   describe("getHookClients", () => {
     it("should return empty array when no hooks configured", () => {
       const config: Config = {
-        sourceTransportType: "httpStream",
-        port: 34000,
+        source: { transportType: "httpStream", port: 34000 },
         target: { transportType: "httpStream", url: "http://localhost:3000" },
         hooks: [],
       };
@@ -37,8 +36,7 @@ describe("Hook Manager", () => {
 
     it("should create remote hook clients for URL-based hooks", () => {
       const config: Config = {
-        sourceTransportType: "httpStream",
-        port: 34000,
+        source: { transportType: "httpStream", port: 34000 },
         target: { transportType: "httpStream", url: "http://localhost:3000" },
         hooks: [
           { url: "http://localhost:3001", name: "audit-hook" },
@@ -67,8 +65,7 @@ describe("Hook Manager", () => {
       };
 
       const config: Config = {
-        sourceTransportType: "httpStream",
-        port: 34000,
+        source: { transportType: "httpStream", port: 34000 },
         target: { transportType: "httpStream", url: "http://localhost:3000" },
         hooks: [mockHook1, mockHook2],
       };
@@ -88,8 +85,7 @@ describe("Hook Manager", () => {
       };
 
       const config: Config = {
-        sourceTransportType: "httpStream",
-        port: 34000,
+        source: { transportType: "httpStream", port: 34000 },
         target: { transportType: "httpStream", url: "http://localhost:3000" },
         hooks: [
           { url: "http://localhost:3001", name: "remote-hook" },

--- a/packages/passthrough-mcp-server/src/index.ts
+++ b/packages/passthrough-mcp-server/src/index.ts
@@ -17,16 +17,14 @@ export {
 // Export types
 export type { PassthroughProxy } from "./proxy/types.js";
 
-export type {
-  StdioProxyConfig,
-  HttpProxyConfig,
-} from "./proxy/createProxies.js";
+export type { StdioProxyConfig } from "./proxy/stdio/stdioPassthroughProxy.js";
+export type { HttpProxyConfig } from "./proxy/http/httpPassthroughProxy.js";
 
 // Export config types
 export type {
   Config,
   TargetConfig,
-  BaseConfig,
+  SourceConfig,
   HookDefinition,
   RemoteHookConfig,
 } from "./proxy/config.js";

--- a/packages/passthrough-mcp-server/src/proxy/config.test.ts
+++ b/packages/passthrough-mcp-server/src/proxy/config.test.ts
@@ -129,8 +129,11 @@ describe("Config Utils", () => {
       const config = loadConfig();
 
       expect(config).toEqual({
-        port: 34000,
-        sourceTransportType: "httpStream",
+        source: {
+          transportType: "httpStream",
+          mcpPath: undefined,
+          port: 34000,
+        },
         target: {
           url: "http://localhost:33000",
           transportType: "httpStream",
@@ -145,7 +148,8 @@ describe("Config Utils", () => {
 
       const config = loadConfig();
 
-      expect(config.sourceTransportType).toBe("httpStream");
+      expect(config.source.transportType).toBe("httpStream");
+      expect(config.source.port).toBe(8080);
       expect(config.target.url).toBe("http://example.com:3000");
       expect(config.target.transportType).toBe("sse");
     });
@@ -171,7 +175,7 @@ describe("Config Utils", () => {
       const config = loadConfig();
 
       // Default case (no args) should be httpStream
-      expect(config.sourceTransportType).toBe("httpStream");
+      expect(config.source.transportType).toBe("httpStream");
 
       // The actual --stdio test is covered by parseServerTransport tests
     });

--- a/packages/passthrough-mcp-server/src/proxy/createProxies.test.ts
+++ b/packages/passthrough-mcp-server/src/proxy/createProxies.test.ts
@@ -3,6 +3,10 @@
  * This file verifies that TypeScript correctly infers return types
  */
 
+import {
+  StreamableHTTPServerTransport,
+  type StreamableHTTPServerTransportOptions,
+} from "@modelcontextprotocol/sdk/server/streamableHttp.js";
 import { describe, expect, expectTypeOf, it, vi } from "vitest";
 import { createPassthroughProxy } from "./createProxies.js";
 import type { HttpPassthroughProxy } from "./http/httpPassthroughProxy";
@@ -23,6 +27,9 @@ describe("createPassthroughProxy type inference", () => {
     const proxy = await createPassthroughProxy({
       sourceTransportType: "httpStream",
       port: 33355,
+      sourceMcpPath: "/mcp", // Path to MCP endpoint of the http server, defaults to /mcp
+      transportFactory: (options: StreamableHTTPServerTransportOptions) =>
+        new StreamableHTTPServerTransport(options),
       target: { url: "http://localhost:3001", transportType: "httpStream" },
     });
 

--- a/packages/passthrough-mcp-server/src/proxy/createProxies.ts
+++ b/packages/passthrough-mcp-server/src/proxy/createProxies.ts
@@ -2,24 +2,26 @@
  * Transport-specific factory functions for creating passthrough proxies
  */
 
-import type { Transport } from "@modelcontextprotocol/sdk/shared/transport.js";
+import type {
+  StreamableHTTPServerTransport,
+  StreamableHTTPServerTransportOptions,
+} from "@modelcontextprotocol/sdk/server/streamableHttp.js";
 import { configureLoggerForStdio } from "../logger/logger.js";
 import type { Config } from "./config.js";
 import { HttpPassthroughProxy } from "./http/httpPassthroughProxy.js";
 import { StdioPassthroughProxy } from "./stdio/stdioPassthroughProxy.js";
 import type { PassthroughProxy } from "./types.js";
 
-export type StdioProxyConfig = Omit<Config, "sourceTransportType" | "port"> & {
+export type StdioProxyConfig = Omit<Config, "sourceTransportType"> & {
   autoStart?: boolean;
 };
 
 export type HttpProxyConfig = Omit<Config, "sourceTransportType"> & {
   port: number;
-  autoStart?: boolean;
-};
-
-export type CustomProxyConfig = Omit<Config, "sourceTransportType"> & {
-  transport: Transport;
+  sourceMcpPath?: string;
+  transportFactory?: (
+    options: StreamableHTTPServerTransportOptions,
+  ) => StreamableHTTPServerTransport;
   autoStart?: boolean;
 };
 

--- a/packages/passthrough-mcp-server/src/proxy/createProxies.ts
+++ b/packages/passthrough-mcp-server/src/proxy/createProxies.ts
@@ -2,28 +2,17 @@
  * Transport-specific factory functions for creating passthrough proxies
  */
 
-import type {
-  StreamableHTTPServerTransport,
-  StreamableHTTPServerTransportOptions,
-} from "@modelcontextprotocol/sdk/server/streamableHttp.js";
 import { configureLoggerForStdio } from "../logger/logger.js";
 import type { Config } from "./config.js";
-import { HttpPassthroughProxy } from "./http/httpPassthroughProxy.js";
-import { StdioPassthroughProxy } from "./stdio/stdioPassthroughProxy.js";
+import {
+  HttpPassthroughProxy,
+  type HttpProxyConfig,
+} from "./http/httpPassthroughProxy.js";
+import {
+  StdioPassthroughProxy,
+  type StdioProxyConfig,
+} from "./stdio/stdioPassthroughProxy.js";
 import type { PassthroughProxy } from "./types.js";
-
-export type StdioProxyConfig = Omit<Config, "sourceTransportType"> & {
-  autoStart?: boolean;
-};
-
-export type HttpProxyConfig = Omit<Config, "sourceTransportType"> & {
-  port: number;
-  sourceMcpPath?: string;
-  transportFactory?: (
-    options: StreamableHTTPServerTransportOptions,
-  ) => StreamableHTTPServerTransport;
-  autoStart?: boolean;
-};
 
 /**
  * Create a stdio passthrough proxy
@@ -47,15 +36,10 @@ export async function createStdioPassthroughProxy(
   // Configure logger for stdio mode to avoid interfering with stdout
   configureLoggerForStdio();
 
-  const { autoStart = true, ...proxyConfig } = config;
-
-  const fullConfig: Config = {
-    ...proxyConfig,
-    sourceTransportType: "stdio",
-  };
-
-  const proxy = new StdioPassthroughProxy(fullConfig);
+  const proxy = new StdioPassthroughProxy(config);
   await proxy.initialize();
+
+  const { autoStart = true } = config;
 
   if (autoStart) {
     await proxy.start();
@@ -84,15 +68,10 @@ export async function createStdioPassthroughProxy(
 export async function createHttpPassthroughProxy(
   config: HttpProxyConfig,
 ): Promise<HttpPassthroughProxy> {
-  const { autoStart = true, ...proxyConfig } = config;
-
-  const fullConfig = {
-    ...proxyConfig,
-    sourceTransportType: "httpStream" as const,
-  };
-
-  const proxy = new HttpPassthroughProxy(fullConfig);
+  const proxy = new HttpPassthroughProxy(config);
   await proxy.initialize();
+
+  const { autoStart = true } = config;
 
   if (autoStart) {
     await proxy.start();
@@ -108,26 +87,26 @@ export async function createHttpPassthroughProxy(
  * @returns Transport-specific proxy type based on config.sourceTransportType
  */
 export async function createPassthroughProxy(
-  config: StdioProxyConfig & { sourceTransportType: "stdio" },
-): Promise<StdioPassthroughProxy>;
-export async function createPassthroughProxy(
-  config: HttpProxyConfig & { sourceTransportType: "httpStream" },
-): Promise<HttpPassthroughProxy>;
-export async function createPassthroughProxy(
   config: Config & { autoStart?: boolean },
 ): Promise<PassthroughProxy> {
-  const { sourceTransportType } = config;
+  const { source, autoStart, ...otherConfig } = config;
+  const { transportType, ...otherSource } = source;
 
-  if (sourceTransportType === "stdio") {
-    return createStdioPassthroughProxy(config);
+  if (transportType === "stdio") {
+    return createStdioPassthroughProxy({
+      ...otherConfig,
+      ...otherSource,
+      autoStart,
+    });
   }
-  if (sourceTransportType === "httpStream") {
-    return createHttpPassthroughProxy(config);
-  }
-  if (sourceTransportType === "custom") {
-    throw new Error("Custom sourceTransport not supported yet.");
+  if (transportType === "httpStream") {
+    return createHttpPassthroughProxy({
+      ...otherConfig,
+      ...otherSource,
+      autoStart,
+    });
   }
   throw new Error(
-    `Unsupported transport type: ${sourceTransportType}. Only stdio and httpStream are supported.`,
+    `Unsupported transport type: ${transportType}. Only stdio and httpStream are supported.`,
   );
 }

--- a/packages/passthrough-mcp-server/src/proxy/stdio/stdioPassthroughProxy.ts
+++ b/packages/passthrough-mcp-server/src/proxy/stdio/stdioPassthroughProxy.ts
@@ -12,6 +12,10 @@ import type { Config } from "../config.js";
 import { createClientTransport, getTargetUrl } from "../transportFactory.js";
 import type { PassthroughProxy } from "../types.js";
 
+export type StdioProxyConfig = Omit<Config, "source"> & {
+  autoStart?: boolean;
+};
+
 export class StdioPassthroughProxy implements PassthroughProxy {
   private isStarted = false;
 
@@ -19,7 +23,7 @@ export class StdioPassthroughProxy implements PassthroughProxy {
   private serverTransport: StdioServerTransport;
   private clientTransport: Transport;
 
-  constructor(private config: Config & { sourceTransportType: "stdio" }) {
+  constructor(private config: StdioProxyConfig) {
     this.serverTransport = new StdioServerTransport();
     this.clientTransport = createClientTransport(
       this.config.target,

--- a/packages/passthrough-mcp-server/src/proxy/transportFactory.ts
+++ b/packages/passthrough-mcp-server/src/proxy/transportFactory.ts
@@ -8,7 +8,7 @@
 import { URL } from "node:url";
 import type { Transport } from "@modelcontextprotocol/sdk/shared/transport.js";
 import { RequestContextAwareStreamableHTTPClientTransport } from "../transports/requestContextAwareStreamableHTTPClientTransport.js";
-import type { BaseConfig, TargetConfig } from "./config.js";
+import type { Config, SourceConfig, TargetConfig } from "./config.js";
 
 /**
  * Helper function to get URL from target config safely
@@ -28,16 +28,6 @@ export function getTargetMcpPath(targetConfig: TargetConfig): string {
     throw new Error("MCP path not available for custom transport type");
   }
   return targetConfig.mcpPath || "/mcp";
-}
-
-/**
- * Helper function to get MCP path from target config safely
- */
-export function getSourceMcpPath(config: BaseConfig): string {
-  if (config.sourceTransportType === "stdio") {
-    throw new Error("MCP path not available for stdio transport type");
-  }
-  return config.sourceMcpPath || "/mcp";
 }
 
 /**

--- a/test/integration/servers/programmatic-passthrough/src/index.ts
+++ b/test/integration/servers/programmatic-passthrough/src/index.ts
@@ -23,8 +23,10 @@ async function main() {
 
   // Create passthrough proxy with programmatic hooks
   const proxy = await createPassthroughProxy({
-    sourceTransportType: "httpStream",
-    port,
+    source: {
+      transportType: "httpStream",
+      port,
+    },
     target: {
       url: targetUrl,
       transportType: "httpStream",


### PR DESCRIPTION
## Summary

This PR restructures the Config interface to use nested `source` and `target` objects for better organization and type safety. This is a breaking change that improves the API design and provides cleaner separation of concerns.

### Key Changes

- **Config Interface Restructuring**: Updated from flat structure to nested `source`/`target` objects
- **Enhanced Type Safety**: Separate `HttpProxyConfig` and `StdioProxyConfig` types for transport-specific configurations
- **Unified API**: Simplified `createPassthroughProxy` function with consistent interface
- **Comprehensive Updates**: Updated all examples, integration tests, and documentation

### Breaking Changes

#### Before (v0.7.0):
```typescript
const proxy = await createPassthroughProxy({
  sourceTransportType: "httpStream",
  port: 3000,
  sourceMcpPath: "/mcp",
  target: {
    url: "http://localhost:3001",
    transportType: "httpStream"
  }
});
```

#### After (v0.7.1):
```typescript
const proxy = await createPassthroughProxy({
  source: {
    transportType: "httpStream",
    port: 3000,
    mcpPath: "/mcp"
  },
  target: {
    url: "http://localhost:3001",
    transportType: "httpStream"
  }
});
```

### Updated Components

- **Config Types**: Restructured with `SourceConfig` and `TargetConfig` for better type safety
- **Proxy Creation**: Enhanced `createPassthroughProxy`, `createHttpPassthroughProxy`, `createStdioPassthroughProxy`
- **CLI Integration**: Updated to use new unified interface
- **Examples**: All programmatic usage examples updated
- **Integration Tests**: Updated test servers and configuration
- **Documentation**: Comprehensive updates to README.md and CHANGELOG.md

## Test Plan

- [x] TypeScript compilation passes (`pnpm typecheck`)
- [x] All unit tests pass (`pnpm test`)
- [x] Linting passes (`pnpm lint`)
- [x] Integration tests updated and passing
- [x] Enhanced test coverage with direct proxy creation function tests
- [x] All examples and documentation updated
- [x] Migration guide provided in CHANGELOG.md

## Migration Impact

This is a **breaking change** requiring users to update their configuration objects. The migration is straightforward:

1. Move `sourceTransportType` to `source.transportType`
2. Move HTTP-specific properties (`port`, `sourceMcpPath`, `transportFactory`) under `source`
3. Rename `sourceMcpPath` to `mcpPath`

The new structure provides:
- **Better Organization**: Clear separation between source and target configuration
- **Enhanced Type Safety**: Transport-specific types prevent invalid property combinations
- **Improved Developer Experience**: More intuitive and consistent API design