### PR TITLE
feat: add metadata options to PassthroughContext

### DIFF
--- a/packages/passthrough-mcp-server/CHANGELOG.md
+++ b/packages/passthrough-mcp-server/CHANGELOG.md
@@ -7,6 +7,24 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.8.1] - 2025-08-18
+
+### Added
+
+- **PassthroughContextOptions**: New configuration interface for controlling metadata behavior
+  - `appendMetadataToRequest`: Control whether metadata is added to requests (default: true)
+  - `appendMetadataToResponse`: Control whether metadata is added to responses (default: true)
+  - `appendMetadataToNotification`: Control whether metadata is added to notifications (default: true)
+- **MetadataHelper**: New utility class that centralizes all metadata operations
+- **PassthroughMetadata**: New interface defining the structure of metadata added to messages
+- PassthroughContext now accepts options as second parameter: `new PassthroughContext(hooks, options)`
+
+### Changed
+
+- Metadata addition is now configurable and conditional based on options
+- Refactored metadata logic from PassthroughContext into dedicated MetadataHelper class
+- All metadata options default to `true` for backward compatibility
+
 ## [0.8.0] - 2025-08-14
 
 ### Changed

--- a/packages/passthrough-mcp-server/package.json
+++ b/packages/passthrough-mcp-server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@civic/passthrough-mcp-server",
-  "version": "0.8.0",
+  "version": "0.8.1",
   "description": "A Model Context Protocol (MCP) server that acts as a passthrough proxy with hook middleware support",
   "keywords": [
     "mcp",

--- a/packages/passthrough-mcp-server/src/index.ts
+++ b/packages/passthrough-mcp-server/src/index.ts
@@ -65,7 +65,13 @@ export { RequestContextAwareStreamableHTTPClientTransport } from "./transports/r
 export {
   PassthroughContext,
   type TransportInterface,
+  type PassthroughContextOptions,
 } from "./shared/passthroughContext.js";
+
+export {
+  MetadataHelper,
+  type PassthroughMetadata,
+} from "./shared/metadataHelper.js";
 
 // Export error constants
 export { MCP_ERROR_CODES, ERROR_MESSAGES } from "./error/errorCodes.js";

--- a/packages/passthrough-mcp-server/src/shared/metadataHelper.test.ts
+++ b/packages/passthrough-mcp-server/src/shared/metadataHelper.test.ts
@@ -1,0 +1,334 @@
+import type {
+  Notification,
+  Request,
+  Result,
+} from "@modelcontextprotocol/sdk/types.js";
+import { describe, expect, it } from "vitest";
+import { MetadataHelper } from "./metadataHelper.js";
+
+describe("MetadataHelper", () => {
+  describe("addMetadataToRequest", () => {
+    it("should add metadata to request when enabled (default)", () => {
+      const helper = new MetadataHelper();
+      const request: Request = {
+        method: "test/method",
+        params: { test: true },
+      };
+
+      const result = helper.addMetadataToRequest(
+        request,
+        "target-123",
+        "source-456",
+      );
+
+      expect(result.params._meta).toBeDefined();
+      expect(result.params._meta.targetSessionId).toBe("target-123");
+      expect(result.params._meta.sourceSessionId).toBe("source-456");
+      expect(result.params._meta.timestamp).toBeDefined();
+      expect(result.params._meta.source).toBe("passthrough-server");
+      expect(result.params.test).toBe(true);
+    });
+
+    it("should add metadata when explicitly enabled", () => {
+      const helper = new MetadataHelper(true, true, true);
+      const request: Request = {
+        method: "test/method",
+        params: { test: true },
+      };
+
+      const result = helper.addMetadataToRequest(
+        request,
+        "target-123",
+        "source-456",
+      );
+
+      expect(result.params._meta).toBeDefined();
+      expect(result.params._meta.targetSessionId).toBe("target-123");
+      expect(result.params._meta.sourceSessionId).toBe("source-456");
+    });
+
+    it("should not add metadata when disabled", () => {
+      const helper = new MetadataHelper(false, true, true);
+      const request: Request = {
+        method: "test/method",
+        params: { test: true },
+      };
+
+      const result = helper.addMetadataToRequest(
+        request,
+        "target-123",
+        "source-456",
+      );
+
+      expect(result).toBe(request);
+      expect(result.params._meta).toBeUndefined();
+      expect(result.params.test).toBe(true);
+    });
+
+    it("should preserve existing _meta when adding metadata", () => {
+      const helper = new MetadataHelper();
+      const request: Request = {
+        method: "test/method",
+        params: {
+          test: true,
+          _meta: {
+            existingField: "existing-value",
+          },
+        },
+      };
+
+      const result = helper.addMetadataToRequest(
+        request,
+        "target-123",
+        "source-456",
+      );
+
+      expect(result.params._meta.existingField).toBe("existing-value");
+      expect(result.params._meta.targetSessionId).toBe("target-123");
+      expect(result.params._meta.sourceSessionId).toBe("source-456");
+    });
+
+    it("should handle undefined session IDs", () => {
+      const helper = new MetadataHelper();
+      const request: Request = {
+        method: "test/method",
+        params: { test: true },
+      };
+
+      const result = helper.addMetadataToRequest(request, undefined, undefined);
+
+      expect(result.params._meta).toBeDefined();
+      expect(result.params._meta.targetSessionId).toBeUndefined();
+      expect(result.params._meta.sourceSessionId).toBeUndefined();
+      expect(result.params._meta.timestamp).toBeDefined();
+      expect(result.params._meta.source).toBe("passthrough-server");
+    });
+  });
+
+  describe("addMetadataToResult", () => {
+    it("should add metadata to result when enabled (default)", () => {
+      const helper = new MetadataHelper();
+      const response: Result = {
+        success: true,
+        data: "test",
+      };
+
+      const result = helper.addMetadataToResult(
+        response,
+        "target-123",
+        "source-456",
+      );
+
+      expect(result._meta).toBeDefined();
+      expect(result._meta.targetSessionId).toBe("target-123");
+      expect(result._meta.sourceSessionId).toBe("source-456");
+      expect(result._meta.timestamp).toBeDefined();
+      expect(result._meta.source).toBe("passthrough-server");
+      expect(result.success).toBe(true);
+    });
+
+    it("should add metadata when explicitly enabled", () => {
+      const helper = new MetadataHelper(true, true, true);
+      const response: Result = {
+        success: true,
+        data: "test",
+      };
+
+      const result = helper.addMetadataToResult(
+        response,
+        "target-123",
+        "source-456",
+      );
+
+      expect(result._meta).toBeDefined();
+      expect(result._meta.targetSessionId).toBe("target-123");
+      expect(result._meta.sourceSessionId).toBe("source-456");
+    });
+
+    it("should not add metadata when disabled", () => {
+      const helper = new MetadataHelper(true, false, true);
+      const response: Result = {
+        success: true,
+        data: "test",
+      };
+
+      const result = helper.addMetadataToResult(
+        response,
+        "target-123",
+        "source-456",
+      );
+
+      expect(result).toBe(response);
+      expect(result._meta).toBeUndefined();
+      expect(result.success).toBe(true);
+    });
+
+    it("should preserve existing _meta when adding metadata", () => {
+      const helper = new MetadataHelper();
+      const response: Result = {
+        success: true,
+        _meta: {
+          existingField: "existing-value",
+        },
+      };
+
+      const result = helper.addMetadataToResult(
+        response,
+        "target-123",
+        "source-456",
+      );
+
+      expect(result._meta.existingField).toBe("existing-value");
+      expect(result._meta.targetSessionId).toBe("target-123");
+      expect(result._meta.sourceSessionId).toBe("source-456");
+    });
+  });
+
+  describe("addMetadataToNotification", () => {
+    it("should add metadata to notification when enabled (default)", () => {
+      const helper = new MetadataHelper();
+      const notification: Notification = {
+        method: "test/notification",
+        params: { test: true },
+      };
+
+      const result = helper.addMetadataToNotification(
+        notification,
+        "session-123",
+      );
+
+      expect(result.params._meta).toBeDefined();
+      expect(result.params._meta.sessionId).toBe("session-123");
+      expect(result.params._meta.timestamp).toBeDefined();
+      expect(result.params._meta.source).toBe("passthrough-server");
+      expect(result.params.test).toBe(true);
+    });
+
+    it("should add metadata when explicitly enabled", () => {
+      const helper = new MetadataHelper(true, true, true);
+      const notification: Notification = {
+        method: "test/notification",
+        params: { test: true },
+      };
+
+      const result = helper.addMetadataToNotification(
+        notification,
+        "session-123",
+      );
+
+      expect(result.params._meta).toBeDefined();
+      expect(result.params._meta.sessionId).toBe("session-123");
+    });
+
+    it("should not add metadata when disabled", () => {
+      const helper = new MetadataHelper(true, true, false);
+      const notification: Notification = {
+        method: "test/notification",
+        params: { test: true },
+      };
+
+      const result = helper.addMetadataToNotification(
+        notification,
+        "session-123",
+      );
+
+      expect(result).toBe(notification);
+      expect(result.params._meta).toBeUndefined();
+      expect(result.params.test).toBe(true);
+    });
+
+    it("should preserve existing _meta when adding metadata", () => {
+      const helper = new MetadataHelper();
+      const notification: Notification = {
+        method: "test/notification",
+        params: {
+          test: true,
+          _meta: {
+            existingField: "existing-value",
+          },
+        },
+      };
+
+      const result = helper.addMetadataToNotification(
+        notification,
+        "session-123",
+      );
+
+      expect(result.params._meta.existingField).toBe("existing-value");
+      expect(result.params._meta.sessionId).toBe("session-123");
+    });
+
+    it("should handle undefined session ID", () => {
+      const helper = new MetadataHelper();
+      const notification: Notification = {
+        method: "test/notification",
+        params: { test: true },
+      };
+
+      const result = helper.addMetadataToNotification(notification, undefined);
+
+      expect(result.params._meta).toBeDefined();
+      expect(result.params._meta.sessionId).toBeUndefined();
+      expect(result.params._meta.timestamp).toBeDefined();
+      expect(result.params._meta.source).toBe("passthrough-server");
+    });
+  });
+
+  describe("constructor options", () => {
+    it("should respect individual option settings", () => {
+      const helper = new MetadataHelper(false, true, false);
+
+      const request: Request = {
+        method: "test/method",
+        params: { test: true },
+      };
+      const response: Result = {
+        success: true,
+      };
+      const notification: Notification = {
+        method: "test/notification",
+        params: { test: true },
+      };
+
+      const requestResult = helper.addMetadataToRequest(request, "t", "s");
+      expect(requestResult.params._meta).toBeUndefined();
+
+      const responseResult = helper.addMetadataToResult(response, "t", "s");
+      expect(responseResult._meta).toBeDefined();
+
+      const notificationResult = helper.addMetadataToNotification(
+        notification,
+        "s",
+      );
+      expect(notificationResult.params._meta).toBeUndefined();
+    });
+
+    it("should default all options to true when not specified", () => {
+      const helper = new MetadataHelper();
+
+      const request: Request = {
+        method: "test/method",
+        params: { test: true },
+      };
+      const response: Result = {
+        success: true,
+      };
+      const notification: Notification = {
+        method: "test/notification",
+        params: { test: true },
+      };
+
+      const requestResult = helper.addMetadataToRequest(request, "t", "s");
+      expect(requestResult.params._meta).toBeDefined();
+
+      const responseResult = helper.addMetadataToResult(response, "t", "s");
+      expect(responseResult._meta).toBeDefined();
+
+      const notificationResult = helper.addMetadataToNotification(
+        notification,
+        "s",
+      );
+      expect(notificationResult.params._meta).toBeDefined();
+    });
+  });
+});

--- a/packages/passthrough-mcp-server/src/shared/metadataHelper.ts
+++ b/packages/passthrough-mcp-server/src/shared/metadataHelper.ts
@@ -1,0 +1,102 @@
+import type {
+  Notification,
+  Request,
+  Result,
+} from "@modelcontextprotocol/sdk/types.js";
+
+/**
+ * Metadata that gets added to requests and results
+ */
+export interface PassthroughMetadata {
+  targetSessionId?: string;
+  sourceSessionId?: string;
+  timestamp: string;
+  source: string;
+}
+
+/**
+ * Helper class for managing metadata operations in the passthrough context
+ */
+export class MetadataHelper {
+  constructor(
+    private readonly appendMetadataToRequest: boolean = true,
+    private readonly appendMetadataToResponse: boolean = true,
+    private readonly appendMetadataToNotification: boolean = true,
+  ) {}
+
+  /**
+   * Add metadata to a request if enabled
+   */
+  addMetadataToRequest<TRequest extends Request>(
+    request: TRequest,
+    targetSessionId?: string,
+    sourceSessionId?: string,
+  ): TRequest {
+    if (!this.appendMetadataToRequest) {
+      return request;
+    }
+
+    return {
+      ...request,
+      params: {
+        ...request.params,
+        _meta: {
+          ...request.params?._meta,
+          targetSessionId,
+          sourceSessionId,
+          timestamp: new Date().toISOString(),
+          source: "passthrough-server",
+        },
+      },
+    };
+  }
+
+  /**
+   * Add metadata to a result if enabled
+   */
+  addMetadataToResult<TResult extends Result>(
+    result: TResult,
+    targetSessionId?: string,
+    sourceSessionId?: string,
+  ): TResult {
+    if (!this.appendMetadataToResponse) {
+      return result;
+    }
+
+    return {
+      ...result,
+      _meta: {
+        ...result._meta,
+        targetSessionId,
+        sourceSessionId,
+        timestamp: new Date().toISOString(),
+        source: "passthrough-server",
+      },
+    };
+  }
+
+  /**
+   * Add metadata to a notification if enabled
+   */
+  addMetadataToNotification(
+    notification: Notification,
+    sessionId?: string,
+  ): Notification {
+    if (!this.appendMetadataToNotification) {
+      return notification;
+    }
+
+    return {
+      ...notification,
+      params: {
+        ...notification.params,
+        _meta: {
+          ...notification.params?._meta,
+          sessionId,
+          timestamp: new Date().toISOString(),
+          source: "passthrough-server",
+        },
+      },
+    };
+  }
+}


### PR DESCRIPTION
## Summary
- Added configurable metadata options to PassthroughContext for controlling when metadata is appended
- Created MetadataHelper utility class to centralize metadata operations
- Maintains backward compatibility with all options defaulting to true

## Changes
- **New PassthroughContextOptions interface** with three boolean options:
  - `appendMetadataToRequest` (default: true)
  - `appendMetadataToResponse` (default: true)  
  - `appendMetadataToNotification` (default: true)
- **MetadataHelper utility class** that encapsulates all metadata addition logic
- **Updated PassthroughContext** to accept options as second parameter and conditionally add metadata
- **Comprehensive test coverage** for all metadata options and combinations
- **Exported new interfaces** (PassthroughContextOptions, PassthroughMetadata) and MetadataHelper class

## Test plan
- [x] All existing tests pass (209 tests)
- [x] Added tests for metadata options in PassthroughContext
- [x] Added unit tests for MetadataHelper class
- [x] Verified backward compatibility (defaults preserve existing behavior)
- [x] TypeScript compilation successful
- [x] Linting passes