### PR TITLE
feat: enhance RequestExtra propagation with complete field mapping

### DIFF
--- a/packages/passthrough-mcp-server/CHANGELOG.md
+++ b/packages/passthrough-mcp-server/CHANGELOG.md
@@ -7,6 +7,27 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.8.6] - 2025-01-27
+
+### Added
+
+- **RequestExtra Mapping Utility**: Created `mapRequestHandlerExtraToRequestExtra` utility function to properly map all fields from MCP SDK's `RequestHandlerExtra` to hook system's `RequestExtra`
+  - Maps authentication info (`authInfo`), request metadata (`_meta`), and HTTP request info (`requestInfo`)
+  - Ensures complete propagation of request context through hook chains
+  - Provides consistent field mapping across all request handlers
+
+### Changed
+
+- **Enhanced Request Context Propagation**: All request handlers now use the mapping utility
+  - Updated 8 request handlers in PassthroughContext to use consistent mapping
+  - Hooks now receive complete request context including authentication and HTTP details
+  - Improved traceability and security context for hook implementations
+
+### Testing
+
+- Added comprehensive tests for RequestExtra mapping functionality
+- Enhanced processor tests to verify complete field propagation through hooks
+
 ## [0.8.5] - 2025-01-23
 
 ### Changed

--- a/packages/passthrough-mcp-server/package.json
+++ b/packages/passthrough-mcp-server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@civic/passthrough-mcp-server",
-  "version": "0.8.5",
+  "version": "0.8.6",
   "description": "A Model Context Protocol (MCP) server that acts as a passthrough proxy with hook middleware support",
   "keywords": [
     "mcp",

--- a/packages/passthrough-mcp-server/src/shared/passthroughContext.ts
+++ b/packages/passthrough-mcp-server/src/shared/passthroughContext.ts
@@ -61,6 +61,7 @@ import {
 import type { HookDefinition } from "../proxy/config.js";
 import { MetadataHelper } from "./metadataHelper.js";
 import { PassthroughEndpoint } from "./passthroughEndpoint.js";
+import { mapRequestHandlerExtraToRequestExtra } from "./requestExtraMapper.js";
 
 /**
  * Options for configuring PassthroughContext behavior
@@ -423,10 +424,8 @@ export class PassthroughContext {
     request: InitializeRequest,
     requestHandlerExtra: RequestHandlerExtra<Request, Notification>,
   ): Promise<InitializeResult> {
-    const requestExtra: RequestExtra = {
-      requestId: requestHandlerExtra.requestId,
-      sessionId: requestHandlerExtra.sessionId,
-    };
+    const requestExtra =
+      mapRequestHandlerExtraToRequestExtra(requestHandlerExtra);
     return this.processServerRequest(
       request,
       requestExtra,
@@ -441,10 +440,8 @@ export class PassthroughContext {
     request: ListToolsRequest,
     requestHandlerExtra: RequestHandlerExtra<Request, Notification>,
   ): Promise<ListToolsResult> {
-    const requestExtra: RequestExtra = {
-      requestId: requestHandlerExtra.requestId,
-      sessionId: requestHandlerExtra.sessionId,
-    };
+    const requestExtra =
+      mapRequestHandlerExtraToRequestExtra(requestHandlerExtra);
     return this.processServerRequest(
       request,
       requestExtra,
@@ -459,10 +456,8 @@ export class PassthroughContext {
     request: CallToolRequest,
     requestHandlerExtra: RequestHandlerExtra<Request, Notification>,
   ): Promise<CallToolResult> {
-    const requestExtra: RequestExtra = {
-      requestId: requestHandlerExtra.requestId,
-      sessionId: requestHandlerExtra.sessionId,
-    };
+    const requestExtra =
+      mapRequestHandlerExtraToRequestExtra(requestHandlerExtra);
     return this.processServerRequest(
       request,
       requestExtra,
@@ -477,10 +472,8 @@ export class PassthroughContext {
     request: ListResourcesRequest,
     requestHandlerExtra: RequestHandlerExtra<Request, Notification>,
   ): Promise<ListResourcesResult> {
-    const requestExtra: RequestExtra = {
-      requestId: requestHandlerExtra.requestId,
-      sessionId: requestHandlerExtra.sessionId,
-    };
+    const requestExtra =
+      mapRequestHandlerExtraToRequestExtra(requestHandlerExtra);
     return this.processServerRequest(
       request,
       requestExtra,
@@ -495,10 +488,8 @@ export class PassthroughContext {
     request: ListResourceTemplatesRequest,
     requestHandlerExtra: RequestHandlerExtra<Request, Notification>,
   ): Promise<ListResourceTemplatesResult> {
-    const requestExtra: RequestExtra = {
-      requestId: requestHandlerExtra.requestId,
-      sessionId: requestHandlerExtra.sessionId,
-    };
+    const requestExtra =
+      mapRequestHandlerExtraToRequestExtra(requestHandlerExtra);
     return this.processServerRequest(
       request,
       requestExtra,
@@ -513,10 +504,8 @@ export class PassthroughContext {
     request: ReadResourceRequest,
     requestHandlerExtra: RequestHandlerExtra<Request, Notification>,
   ): Promise<ReadResourceResult> {
-    const requestExtra: RequestExtra = {
-      requestId: requestHandlerExtra.requestId,
-      sessionId: requestHandlerExtra.sessionId,
-    };
+    const requestExtra =
+      mapRequestHandlerExtraToRequestExtra(requestHandlerExtra);
     return this.processServerRequest(
       request,
       requestExtra,
@@ -539,10 +528,8 @@ export class PassthroughContext {
       );
     }
 
-    const requestExtra: RequestExtra = {
-      requestId: requestHandlerExtra.requestId,
-      sessionId: requestHandlerExtra.sessionId,
-    };
+    const requestExtra =
+      mapRequestHandlerExtraToRequestExtra(requestHandlerExtra);
     return this.processServerRequest(
       request,
       requestExtra,
@@ -615,10 +602,8 @@ export class PassthroughContext {
     request: Request,
     requestHandlerExtra: RequestHandlerExtra<Request, Notification>,
   ): Promise<Result> {
-    const requestExtra: RequestExtra = {
-      requestId: requestHandlerExtra.requestId,
-      sessionId: requestHandlerExtra.sessionId,
-    };
+    const requestExtra =
+      mapRequestHandlerExtraToRequestExtra(requestHandlerExtra);
     return this.processClientRequest(
       request,
       requestExtra,

--- a/packages/passthrough-mcp-server/src/shared/requestExtraMapper.test.ts
+++ b/packages/passthrough-mcp-server/src/shared/requestExtraMapper.test.ts
@@ -1,0 +1,144 @@
+import type { RequestHandlerExtra } from "@modelcontextprotocol/sdk/shared/protocol.js";
+import type { Notification, Request } from "@modelcontextprotocol/sdk/types.js";
+import { describe, expect, it } from "vitest";
+import { mapRequestHandlerExtraToRequestExtra } from "./requestExtraMapper.js";
+
+describe("mapRequestHandlerExtraToRequestExtra", () => {
+  it("should map all fields from RequestHandlerExtra to RequestExtra", () => {
+    const mockRequestHandlerExtra: RequestHandlerExtra<Request, Notification> =
+      {
+        requestId: "test-request-id",
+        sessionId: "test-session-id",
+        authInfo: {
+          access_token: "test-token",
+          token_type: "Bearer",
+        },
+        _meta: {
+          test: "metadata",
+        },
+        requestInfo: {
+          url: "http://test.example.com",
+          method: "POST",
+          headers: { "content-type": "application/json" },
+        },
+        signal: new AbortController().signal,
+        sendNotification: async () => {},
+        sendRequest: async () => ({ result: {} }),
+      };
+
+    const result = mapRequestHandlerExtraToRequestExtra(
+      mockRequestHandlerExtra,
+    );
+
+    expect(result).toEqual({
+      requestId: "test-request-id",
+      sessionId: "test-session-id",
+      authInfo: {
+        access_token: "test-token",
+        token_type: "Bearer",
+      },
+      _meta: {
+        test: "metadata",
+      },
+      requestInfo: {
+        url: "http://test.example.com",
+        method: "POST",
+        headers: { "content-type": "application/json" },
+      },
+    });
+  });
+
+  it("should handle minimal RequestHandlerExtra with only required fields", () => {
+    const mockRequestHandlerExtra: RequestHandlerExtra<Request, Notification> =
+      {
+        requestId: "test-request-id",
+        signal: new AbortController().signal,
+        sendNotification: async () => {},
+        sendRequest: async () => ({ result: {} }),
+      };
+
+    const result = mapRequestHandlerExtraToRequestExtra(
+      mockRequestHandlerExtra,
+    );
+
+    expect(result).toEqual({
+      requestId: "test-request-id",
+      sessionId: undefined,
+      authInfo: undefined,
+      _meta: undefined,
+      requestInfo: undefined,
+    });
+  });
+
+  it("should handle RequestHandlerExtra with partial optional fields", () => {
+    const mockRequestHandlerExtra: RequestHandlerExtra<Request, Notification> =
+      {
+        requestId: "test-request-id",
+        sessionId: "test-session-id",
+        signal: new AbortController().signal,
+        sendNotification: async () => {},
+        sendRequest: async () => ({ result: {} }),
+      };
+
+    const result = mapRequestHandlerExtraToRequestExtra(
+      mockRequestHandlerExtra,
+    );
+
+    expect(result).toEqual({
+      requestId: "test-request-id",
+      sessionId: "test-session-id",
+      authInfo: undefined,
+      _meta: undefined,
+      requestInfo: undefined,
+    });
+  });
+
+  it("should not include fields not present in RequestExtra", () => {
+    const mockRequestHandlerExtra: RequestHandlerExtra<Request, Notification> =
+      {
+        requestId: "test-request-id",
+        sessionId: "test-session-id",
+        signal: new AbortController().signal,
+        sendNotification: async () => {},
+        sendRequest: async () => ({ result: {} }),
+      };
+
+    const result = mapRequestHandlerExtraToRequestExtra(
+      mockRequestHandlerExtra,
+    );
+
+    // Verify that signal, sendNotification, and sendRequest are not included
+    expect(result).not.toHaveProperty("signal");
+    expect(result).not.toHaveProperty("sendNotification");
+    expect(result).not.toHaveProperty("sendRequest");
+  });
+
+  it("should preserve complex authInfo structure", () => {
+    const mockRequestHandlerExtra: RequestHandlerExtra<Request, Notification> =
+      {
+        requestId: "test-request-id",
+        authInfo: {
+          access_token: "complex-token",
+          token_type: "Bearer",
+          expires_in: 3600,
+          refresh_token: "refresh-token",
+          scope: "read write",
+        },
+        signal: new AbortController().signal,
+        sendNotification: async () => {},
+        sendRequest: async () => ({ result: {} }),
+      };
+
+    const result = mapRequestHandlerExtraToRequestExtra(
+      mockRequestHandlerExtra,
+    );
+
+    expect(result.authInfo).toEqual({
+      access_token: "complex-token",
+      token_type: "Bearer",
+      expires_in: 3600,
+      refresh_token: "refresh-token",
+      scope: "read write",
+    });
+  });
+});

--- a/packages/passthrough-mcp-server/src/shared/requestExtraMapper.ts
+++ b/packages/passthrough-mcp-server/src/shared/requestExtraMapper.ts
@@ -1,0 +1,22 @@
+import type { RequestExtra } from "@civic/hook-common";
+import type { RequestHandlerExtra } from "@modelcontextprotocol/sdk/shared/protocol.js";
+import type { Notification, Request } from "@modelcontextprotocol/sdk/types.js";
+
+/**
+ * Maps RequestHandlerExtra from the MCP SDK to RequestExtra for hooks.
+ * This utility ensures all relevant fields are properly transferred.
+ */
+export function mapRequestHandlerExtraToRequestExtra<
+  SendRequestT extends Request,
+  SendNotificationT extends Notification,
+>(
+  requestHandlerExtra: RequestHandlerExtra<SendRequestT, SendNotificationT>,
+): RequestExtra {
+  return {
+    requestId: requestHandlerExtra.requestId,
+    sessionId: requestHandlerExtra.sessionId,
+    authInfo: requestHandlerExtra.authInfo,
+    _meta: requestHandlerExtra._meta,
+    requestInfo: requestHandlerExtra.requestInfo,
+  };
+}


### PR DESCRIPTION
## Summary
- Adds comprehensive mapping from RequestHandlerExtra to RequestExtra
- Ensures all request context fields are properly propagated to hooks
- Improves hook visibility into authentication and HTTP request details

## Changes
- Created `mapRequestHandlerExtraToRequestExtra` utility function to map all relevant fields
- Updated all 8 request handlers in PassthroughContext to use the mapping utility
- Added comprehensive tests for the mapping functionality
- Updated existing tests to verify complete RequestExtra propagation

## Test plan
- [x] All existing tests pass
- [x] New tests for mapping utility pass
- [x] Enhanced processor tests verify field propagation
- [x] Type checking passes
- [x] Linting passes