### PR TITLE
feat: expose proxyContext and sessionManager in proxy implementations

### DIFF
--- a/packages/passthrough-mcp-server/CHANGELOG.md
+++ b/packages/passthrough-mcp-server/CHANGELOG.md
@@ -7,6 +7,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.8.7] - 2025-01-02
+
+### Changed
+
+- **Exposed proxyContext in StdioPassthroughProxy**: Made the `proxyContext` property public and readonly in `StdioPassthroughProxy` to allow external access to the PassthroughContext instance
+- **Exposed sessionManager in HttpPassthroughProxy**: Made the `sessionManager` property public and readonly in `HttpPassthroughProxy` to allow external access to the McpSessionManager instance
+
 ## [0.8.6] - 2025-01-27
 
 ### Added

--- a/packages/passthrough-mcp-server/package.json
+++ b/packages/passthrough-mcp-server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@civic/passthrough-mcp-server",
-  "version": "0.8.6",
+  "version": "0.8.7",
   "description": "A Model Context Protocol (MCP) server that acts as a passthrough proxy with hook middleware support",
   "keywords": [
     "mcp",

--- a/packages/passthrough-mcp-server/src/proxy/http/httpPassthroughProxy.ts
+++ b/packages/passthrough-mcp-server/src/proxy/http/httpPassthroughProxy.ts
@@ -38,7 +38,7 @@ export type HttpProxyConfig = Omit<Config, "source"> & {
 export class HttpPassthroughProxy implements PassthroughProxy {
   private httpServer!: HttpServer;
   private isStarted = false;
-  private sessionManager: McpSessionManager;
+  public readonly sessionManager: McpSessionManager;
 
   constructor(private config: HttpProxyConfig) {
     this.sessionManager = new McpSessionManager();

--- a/packages/passthrough-mcp-server/src/proxy/stdio/stdioPassthroughProxy.ts
+++ b/packages/passthrough-mcp-server/src/proxy/stdio/stdioPassthroughProxy.ts
@@ -19,7 +19,7 @@ export type StdioProxyConfig = Omit<Config, "source"> & {
 export class StdioPassthroughProxy implements PassthroughProxy {
   private isStarted = false;
 
-  private proxyContext: PassthroughContext;
+  public readonly proxyContext: PassthroughContext;
   private serverTransport: StdioServerTransport;
   private clientTransport: Transport;
 


### PR DESCRIPTION
## Summary
- Exposed `proxyContext` as public readonly in `StdioPassthroughProxy` to allow external access to the PassthroughContext instance
- Exposed `sessionManager` as public readonly in `HttpPassthroughProxy` to allow external access to the McpSessionManager instance
- Bumped version to 0.8.7

## Test plan
- [x] All existing tests pass
- [x] Linting passes
- [x] No breaking changes - only exposing previously private properties as public readonly